### PR TITLE
[no-deprecated-colors] Handle `sx` prop edge cases

### DIFF
--- a/.changeset/weak-tips-brush.md
+++ b/.changeset/weak-tips-brush.md
@@ -1,0 +1,17 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+The `no-deprecated-colors` rule can now find deprecated colors in the following cases:
+
+* Nested `sx` properties:
+ 
+   ```jsx
+  <Box sx={{'&:hover': {bg: 'bg.primary'}}}>
+   ```
+
+* Functions in `sx` prop:
+
+   ```jsx
+  <Box sx={{boxShadow: theme => `0 1px 2px ${theme.colors.text.primary}`}}>
+   ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-primer-react",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2533,6 +2533,11 @@
           "dev": true
         }
       }
+    },
+    "eslint-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-traverse/-/eslint-traverse-1.0.0.tgz",
+      "integrity": "sha512-bSp37rQs93LF8rZ409EI369DGCI4tELbFVmFNxI6QbuveS7VRxYVyUhwDafKN/enMyUh88HQQ7ZoGUHtPuGdcw=="
     },
     "eslint-utils": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "eslint": ">=4.19.0",
     "@primer/primitives": ">=4.6.2"
   },
-  "prettier": "@github/prettier-config"
+  "prettier": "@github/prettier-config",
+  "dependencies": {
+    "eslint-traverse": "^1.0.0"
+  }
 }

--- a/src/rules/__tests__/no-deprecated-colors.test.js
+++ b/src/rules/__tests__/no-deprecated-colors.test.js
@@ -80,6 +80,15 @@ ruleTester.run('no-deprecated-colors', rule, {
       ]
     },
     {
+      code: `import {Box} from "@primer/components"; <Box sx={{"&:hover": {bg: "bg.primary"}}} />`,
+      output: `import {Box} from "@primer/components"; <Box sx={{"&:hover": {bg: "canvas.default"}}} />`,
+      errors: [
+        {
+          message: '"bg.primary" is deprecated. Use "canvas.default" instead.'
+        }
+      ]
+    },
+    {
       code: `import {Box} from "@primer/components"; <Box color="auto.green.5" />`,
       errors: [
         {

--- a/src/rules/__tests__/no-deprecated-colors.test.js
+++ b/src/rules/__tests__/no-deprecated-colors.test.js
@@ -80,6 +80,33 @@ ruleTester.run('no-deprecated-colors', rule, {
       ]
     },
     {
+      code: `import {Box} from "@primer/components"; <Box sx={{boxShadow: theme => theme.shadows.autocomplete.shadow}} />`,
+      output: `import {Box} from "@primer/components"; <Box sx={{boxShadow: theme => theme.shadows.shadow.medium}} />`,
+      errors: [
+        {
+          message: '"theme.shadows.autocomplete.shadow" is deprecated. Use "theme.shadows.shadow.medium" instead.'
+        }
+      ]
+    },
+    {
+      code: `import {Box} from "@primer/components"; <Box sx={{boxShadow: theme => \`0 1px 2px \${theme.colors.text.primary}\`}} />`,
+      output: `import {Box} from "@primer/components"; <Box sx={{boxShadow: theme => \`0 1px 2px \${theme.colors.fg.default}\`}} />`,
+      errors: [
+        {
+          message: '"theme.colors.text.primary" is deprecated. Use "theme.colors.fg.default" instead.'
+        }
+      ]
+    },
+    {
+      code: `import {Box} from "@primer/components"; <Box sx={{boxShadow: t => \`0 1px 2px \${t.colors.text.primary}\`}} />`,
+      output: `import {Box} from "@primer/components"; <Box sx={{boxShadow: t => \`0 1px 2px \${t.colors.fg.default}\`}} />`,
+      errors: [
+        {
+          message: '"t.colors.text.primary" is deprecated. Use "t.colors.fg.default" instead.'
+        }
+      ]
+    },
+    {
       code: `import {Box} from "@primer/components"; <Box sx={{"&:hover": {bg: "bg.primary"}}} />`,
       output: `import {Box} from "@primer/components"; <Box sx={{"&:hover": {bg: "canvas.default"}}} />`,
       errors: [


### PR DESCRIPTION
The `no-deprecated-colors` rule can now find deprecated colors in the following cases:

* Nested `sx` properties:
 
   ```jsx
  <Box sx={{'&:hover': {bg: 'bg.primary'}}}>
   ```

* Functions in `sx` prop:

   ```jsx
  <Box sx={{boxShadow: theme => `0 1px 2px ${theme.colors.text.primary}`}}>
   ```