### PR TITLE
[no-deprecated-colors] Add `checkImport` option

### DIFF
--- a/docs/rules/no-deprecated-colors.md
+++ b/docs/rules/no-deprecated-colors.md
@@ -2,12 +2,11 @@
 
 🔧 The `--fix` option on the [ESLint CLI](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-[Theming](https://primer.style/react/theming) in Primer React is made possible by a theme object that defines your application's colors, spacing, fonts, and more. The color variables in Primer React's [default theme object](https://primer.style/react/theme-reference) are pulled from [Primer Primitives](https://github.com/primer/primitives). When a color variable is deprecated in Primer Primitives, it's important to remove references to that color variable in your application before it's removed from the library.   
+[Theming](https://primer.style/react/theming) in Primer React is made possible by a theme object that defines your application's colors, spacing, fonts, and more. The color variables in Primer React's [default theme object](https://primer.style/react/theme-reference) are pulled from [Primer Primitives](https://github.com/primer/primitives). When a color variable is deprecated in Primer Primitives, it's important to remove references to that color variable in your application before it's removed from the library.
 
 ## Rule details
 
 This rule disallows references to color variables that are deprecated in [Primer Primitives](https://github.com/primer/primitives).
-
 
 👎 Examples of **incorrect** code for this rule:
 
@@ -21,7 +20,7 @@ const SystemPropExample() = () => <Box color="some.deprecated.color">Incorrect</
 const SxPropExample() = () => <Box sx={{color: 'some.deprecated.color'}}>Incorrect</Box>
 
 const ThemeGetExample = styled.div`
-  color: ${themeGet('some.deprecated.color')};
+  color: ${themeGet('colors.some.deprecated.color')};
 `
 ```
 
@@ -37,6 +36,16 @@ const SystemPropExample() = () => <Box color="some.color">Incorrect</Box>
 const SxPropExample() = () => <Box sx={{color: 'some.color'}}>Incorrect</Box>
 
 const ThemeGetExample = styled.div`
-  color: ${themeGet('some.color')};
+  color: ${themeGet('colors.some.color')};
 `
 ```
+
+## Options
+
+- `checkImport` (default: `true`)
+
+  By default, the `no-deprecated-colors` rule will only check for deprecated colors used in functions and components that are imported from `@primer/components`. You can disable this behavior by setting `checkImport` to `false`. This is useful for linting custom components that that pass color-related props down to Primer React components.
+
+  ```
+  "primer-react/no-deprecated-colors": ["warn", {"checkImport": false}]
+  ```

--- a/src/rules/__tests__/no-deprecated-colors.test.js
+++ b/src/rules/__tests__/no-deprecated-colors.test.js
@@ -44,6 +44,16 @@ ruleTester.run('no-deprecated-colors', rule, {
       ]
     },
     {
+      code: `import {Box} from "../components"; function Example() { return <Box color="text.primary">Hello</Box> }`,
+      output: `import {Box} from "../components"; function Example() { return <Box color="fg.default">Hello</Box> }`,
+      options: [{checkImport: false}],
+      errors: [
+        {
+          message: '"text.primary" is deprecated. Use "fg.default" instead.'
+        }
+      ]
+    },
+    {
       code: `import Box from '@primer/components/lib-esm/Box'; function Example() { return <Box color="text.primary">Hello</Box> }`,
       output: `import Box from '@primer/components/lib-esm/Box'; function Example() { return <Box color="fg.default">Hello</Box> }`,
       errors: [

--- a/src/rules/no-deprecated-colors.js
+++ b/src/rules/no-deprecated-colors.js
@@ -5,13 +5,28 @@ const styledSystemColorProps = ['color', 'bg', 'backgroundColor', 'borderColor',
 module.exports = {
   meta: {
     type: 'suggestion',
-    fixable: 'code'
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          checkImport: {
+            type: 'boolean'
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   },
   create(context) {
+    // If `shouldCheckImport` is true, this rule will only check for deprecated colors
+    // used in functions and components that are imported from `@primer/components`.
+    const shouldCheckImport = context.options[0] ? context.options[0].checkImport : true
+
     return {
       JSXOpeningElement(node) {
         // Skip if component was not imported from @primer/components
-        if (!isPrimerComponent(node.name, context.getScope(node))) {
+        if (shouldCheckImport && !isPrimerComponent(node.name, context.getScope(node))) {
           return
         }
 
@@ -49,7 +64,10 @@ module.exports = {
       CallExpression(node) {
         // Skip if not calling the `themeGet` or `get` function
         // `get` is the internal version of `themeGet` that's used in the primer/react repository
-        if (!isThemeGet(node.callee, context.getScope(node)) && !isGet(node.callee, context.getScope(node))) {
+        if (
+          !isThemeGet(node.callee, context.getScope(node), shouldCheckImport) &&
+          !isGet(node.callee, context.getScope(node))
+        ) {
           return
         }
 
@@ -95,11 +113,17 @@ function isPrimerComponent(identifier, scope) {
   return isImportedFrom(/^@primer\/components/, identifier, scope)
 }
 
-function isThemeGet(identifier, scope) {
-  return isImportedFrom(/^@primer\/components/, identifier, scope) && identifier.name === 'themeGet'
+function isThemeGet(identifier, scope, shouldCheckImport = true) {
+  if (shouldCheckImport) {
+    return isImportedFrom(/^@primer\/components/, identifier, scope) && identifier.name === 'themeGet'
+  }
+
+  return identifier.name === 'themeGet'
 }
 
+// `get` is the internal version of `themeGet` that's used in the primer/react repository.
 function isGet(identifier, scope) {
+  // This is a flaky way to check for the `get` function and should probably be improved.
   return isImportedFrom(/^\.\.?\/constants$/, identifier, scope) && identifier.name === 'get'
 }
 


### PR DESCRIPTION
## Problem

Memex has components that pass system props down to Primer React components ([example](https://github.com/github/memex/blob/9e699b5d4ba8f32aab74d82949de5ad23aa61b1a/src/client/components/common/borderless-text-input.tsx)). 

```jsx
import {TextInput} from '@primer/components'
import styled from 'styled-components'

const BorderlessTextInput = styled(TextInput)`
  border: 0;
`
```

If someone passes a deprecated to these wrapper components, the `no-deprecated-colors` rule won't notice it because it only looks at props passed to components imported from `@primer/components`.

```jsx
<BorderlessTextInput color="some.deprecated.color" />
// `no-deprecated-colors` won't warn us about this
```

## Solution

In this PR, I added a `checkImport` option. By default, the `no-deprecated-colors` rule will only check for deprecated colors used in functions and components that are imported from `@primer/components`. You can disable this behavior by setting `checkImport` to `false`. This is useful for linting custom components that that pass color-related props down to Primer React components.