### PR TITLE
Add configurable option to ignore valid import check

### DIFF
--- a/src/rules/no-deprecated-colors.js
+++ b/src/rules/no-deprecated-colors.js
@@ -11,8 +11,11 @@ module.exports = {
   create(context) {
     return {
       JSXOpeningElement(node) {
+        const options = context.options[0] || {}
+        const ignoreImport = options.ignoreImport || false
+
         // Skip if component was not imported from @primer/components
-        if (!isPrimerComponent(node.name, context.getScope(node))) {
+        if (!ignoreImport && !isPrimerComponent(node.name, context.getScope(node))) {
           return
         }
 


### PR DESCRIPTION
Markdown comments won't necessarily have a well-formed import expression, add an escape hatch for eslint configuration to ignore the valid import check.

Before merge, the readme for the rule should be updated to document this new flag.