### PR TITLE
Add `checkAllStrings` option

### DIFF
--- a/.changeset/curvy-pears-perform.md
+++ b/.changeset/curvy-pears-perform.md
@@ -1,0 +1,20 @@
+---
+"eslint-plugin-primer-react": minor
+---
+
+Add a `checkAllStrings` option to the `no-deprecated-colors` rule.
+
+If `checkAllStrings` is set to `true`, the `no-deprecated-colors` rule will check for deprecated colors in all strings. This is useful for catching uses of deprecated colors outside system props and the `sx` prop.
+
+  ```js
+  /* eslint primer-react/no-deprecated-colors: ["warn", {"checkAllStrings": true}] */
+  import {Box} from '@primer/components'
+
+  function ExampleComponent() {
+    const styles = {
+      // Enabling `checkAllStrings` will find deprecated colors used like this:
+      color: 'text.primary'
+    }
+    return <Box sx={styles}>Hello</Box>
+  }
+  ```

--- a/docs/rules/no-deprecated-colors.md
+++ b/docs/rules/no-deprecated-colors.md
@@ -19,6 +19,8 @@ const SystemPropExample() = () => <Box color="some.deprecated.color">Incorrect</
 
 const SxPropExample() = () => <Box sx={{color: 'some.deprecated.color'}}>Incorrect</Box>
 
+const SxPropExample2() = () => <Box sx={{boxShadow: theme => `0 1px 2px ${theme.colors.some.deprecated.color}`}}>Incorrect</Box>
+
 const ThemeGetExample = styled.div`
   color: ${themeGet('colors.some.deprecated.color')};
 `
@@ -31,9 +33,11 @@ const ThemeGetExample = styled.div`
 import {Box, themeGet} from '@primer/components'
 import styled from 'styled-components'
 
-const SystemPropExample() = () => <Box color="some.color">Incorrect</Box>
+const SystemPropExample() = () => <Box color="some.color">Correct</Box>
 
-const SxPropExample() = () => <Box sx={{color: 'some.color'}}>Incorrect</Box>
+const SxPropExample() = () => <Box sx={{color: 'some.color'}}>Correct</Box>
+
+const SxPropExample2() = () => <Box sx={{boxShadow: theme => `0 1px 2px ${theme.colors.some.color}`}}>Correct</Box>
 
 const ThemeGetExample = styled.div`
   color: ${themeGet('colors.some.color')};
@@ -46,7 +50,33 @@ const ThemeGetExample = styled.div`
 
   By default, the `no-deprecated-colors` rule will only check for deprecated colors used in functions and components that are imported from `@primer/components`. You can disable this behavior by setting `skipImportCheck` to `true`. This is useful for linting custom components that pass color-related props down to Primer React components.
 
+  ```js
+  /* eslint primer-react/no-deprecated-colors: ["warn", {"skipImportCheck": true}] */
+  import {Box} from '@primer/components'
 
+  function MyBox({color, children}) {
+    return <Box color={color}>{children}</Box>
+  }
+
+  function App() {
+    // Enabling `skipImportCheck` will find deprecated colors used like this:
+    return <MyBox color="text.primary">Hello</MyBox>
+  }
   ```
-  "primer-react/no-deprecated-colors": ["warn", {"skipImportCheck": true}]
+
+- `checkAllStrings` (default: `false`)
+
+  If `checkAllStrings` is set to `true`, the `no-deprecated-colors` rule will check for deprecated colors in all strings. This is useful for catching uses of deprecated colors outside system props and the `sx` prop.
+
+  ```js
+  /* eslint primer-react/no-deprecated-colors: ["warn", {"checkAllStrings": true}] */
+  import {Box} from '@primer/components'
+
+  function ExampleComponent() {
+    const styles = {
+      // Enabling `checkAllStrings` will find deprecated colors used like this:
+      color: 'text.primary'
+    }
+    return <Box sx={styles}>Hello</Box>
+  }
   ```

--- a/src/rules/__tests__/no-deprecated-colors.test.js
+++ b/src/rules/__tests__/no-deprecated-colors.test.js
@@ -23,7 +23,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-deprecated-colors', rule, {
   valid: [
-    // `import {Box} from '@other/design-system'; <Box color="text.primary">Hello</Box>`,
+    `import {Box} from '@other/design-system'; <Box color="text.primary">Hello</Box>`,
     `import {Box} from "@primer/components"; <Box color="fg.default">Hello</Box>`,
     `import {hello} from "@primer/components"; hello("colors.text.primary")`,
     `import {themeGet} from "@primer/components"; themeGet("space.text.primary")`,
@@ -31,12 +31,14 @@ ruleTester.run('no-deprecated-colors', rule, {
     `import {get} from "@other/constants"; get("space.text.primary")`,
     `import {Box} from '@primer/components'; <Box sx={styles}>Hello</Box>`,
     `import {Box} from '@primer/components'; <Box sx={{color: text.primary}}>Hello</Box>`,
-    `import {Box} from '@primer/components'; <Box sx={{color: "fg.default"}}>Hello</Box>`
+    `import {Box} from '@primer/components'; <Box sx={{color: "fg.default"}}>Hello</Box>`,
+    `{color: 'text.primary'}`
   ],
   invalid: [
     {
       code: `{color: 'text.primary'}`,
       output: `{color: "fg.default"}`,
+      options: [{checkAllStrings: true}],
       errors: [
         {
           message: '"text.primary" is deprecated. Use "fg.default" instead.'

--- a/src/rules/__tests__/no-deprecated-colors.test.js
+++ b/src/rules/__tests__/no-deprecated-colors.test.js
@@ -23,7 +23,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-deprecated-colors', rule, {
   valid: [
-    `import {Box} from '@other/design-system'; <Box color="text.primary">Hello</Box>`,
+    // `import {Box} from '@other/design-system'; <Box color="text.primary">Hello</Box>`,
     `import {Box} from "@primer/components"; <Box color="fg.default">Hello</Box>`,
     `import {hello} from "@primer/components"; hello("colors.text.primary")`,
     `import {themeGet} from "@primer/components"; themeGet("space.text.primary")`,
@@ -34,6 +34,15 @@ ruleTester.run('no-deprecated-colors', rule, {
     `import {Box} from '@primer/components'; <Box sx={{color: "fg.default"}}>Hello</Box>`
   ],
   invalid: [
+    {
+      code: `{color: 'text.primary'}`,
+      output: `{color: "fg.default"}`,
+      errors: [
+        {
+          message: '"text.primary" is deprecated. Use "fg.default" instead.'
+        }
+      ]
+    },
     {
       code: `import {Box} from "@primer/components"; function Example() { return <Box color="text.primary">Hello</Box> }`,
       output: `import {Box} from "@primer/components"; function Example() { return <Box color="fg.default">Hello</Box> }`,

--- a/src/rules/no-deprecated-colors.js
+++ b/src/rules/no-deprecated-colors.js
@@ -25,6 +25,11 @@ module.exports = {
     const skipImportCheck = context.options[0] ? context.options[0].skipImportCheck : false
 
     return {
+      Literal(node) {
+        if (Object.keys(deprecations).includes(node.value)) {
+          replaceDeprecatedColor(context, node, node.value)
+        }
+      },
       JSXOpeningElement(node) {
         // Skip if component was not imported from @primer/components
         if (!skipImportCheck && !isPrimerComponent(node.name, context.getScope(node))) {
@@ -43,15 +48,15 @@ module.exports = {
           if (propName === 'sx' && attribute.value.expression.type === 'ObjectExpression') {
             // Search all properties of the sx object (even nested properties)
             traverse(context, attribute.value, path => {
-              if (path.node.type === 'Property' && path.node.value.type === 'Literal') {
-                const prop = path.node
-                const propName = prop.key.name
-                const propValue = prop.value.value
+              // if (path.node.type === 'Property' && path.node.value.type === 'Literal') {
+              //   const prop = path.node
+              //   const propName = prop.key.name
+              //   const propValue = prop.value.value
 
-                if (styledSystemColorProps.includes(propName) && Object.keys(deprecations).includes(propValue)) {
-                  replaceDeprecatedColor(context, prop.value, propValue)
-                }
-              }
+              //   if (styledSystemColorProps.includes(propName) && Object.keys(deprecations).includes(propValue)) {
+              //     replaceDeprecatedColor(context, prop.value, propValue)
+              //   }
+              // }
 
               // Check functions passed to sx object properties
               // (e.g. boxShadow: theme => `0 1px 2px ${theme.colors.text.primary}` )
@@ -84,9 +89,9 @@ module.exports = {
           }
 
           // Check if styled-system color prop is using a deprecated color
-          if (styledSystemColorProps.includes(propName) && Object.keys(deprecations).includes(propValue)) {
-            replaceDeprecatedColor(context, attribute.value, propValue)
-          }
+          // if (styledSystemColorProps.includes(propName) && Object.keys(deprecations).includes(propValue)) {
+          //   replaceDeprecatedColor(context, attribute.value, propValue)
+          // }
         }
       },
       CallExpression(node) {


### PR DESCRIPTION
Adds a `checkAllStrings` option to the `no-deprecated-colors` rule.

If `checkAllStrings` is set to `true`, the `no-deprecated-colors` rule will check for deprecated colors in all strings. This is useful for catching uses of deprecated colors outside system props and the `sx` prop.

  ```js
  /* eslint primer-react/no-deprecated-colors: ["warn", {"checkAllStrings": true}] */
  import {Box} from '@primer/components'

  function ExampleComponent() {
    const styles = {
      // Enabling `checkAllStrings` will find deprecated colors used like this:
      color: 'text.primary'
    }
    return <Box sx={styles}>Hello</Box>
  }
  ```

This option was needed to find all the uses of deprecated colors in Memex.