### PR TITLE
Ignore non-literal, non-string arguments to `themeGet` in `no-deprecated-colors` rule

### DIFF
--- a/.changeset/friendly-months-hope.md
+++ b/.changeset/friendly-months-hope.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+Ignore non-literal, non-string arguments to `themeGet` in `no-deprecated-colors` rule

--- a/src/rules/__tests__/no-deprecated-colors.test.js
+++ b/src/rules/__tests__/no-deprecated-colors.test.js
@@ -31,6 +31,7 @@ ruleTester.run('no-deprecated-colors', rule, {
     `import {Box} from "@primer/components"; <Box color="fg.default">Hello</Box>`,
     `import {hello} from "@primer/components"; hello("colors.text.primary")`,
     `import {themeGet} from "@primer/components"; themeGet("space.text.primary")`,
+    `import {themeGet} from "@primer/components"; themeGet(props.backgroundColorThemeValue)`,
     `import {themeGet} from "@other/design-system"; themeGet("colors.text.primary")`,
     `import {get} from "@other/constants"; get("space.text.primary")`,
     `import {Box} from '@primer/components'; <Box sx={styles}>Hello</Box>`,

--- a/src/rules/__tests__/no-deprecated-colors.test.js
+++ b/src/rules/__tests__/no-deprecated-colors.test.js
@@ -32,6 +32,7 @@ ruleTester.run('no-deprecated-colors', rule, {
     `import {hello} from "@primer/components"; hello("colors.text.primary")`,
     `import {themeGet} from "@primer/components"; themeGet("space.text.primary")`,
     `import {themeGet} from "@primer/components"; themeGet(props.backgroundColorThemeValue)`,
+    `import {themeGet} from "@primer/components"; themeGet(2)`,
     `import {themeGet} from "@other/design-system"; themeGet("colors.text.primary")`,
     `import {get} from "@other/constants"; get("space.text.primary")`,
     `import {Box} from '@primer/components'; <Box sx={styles}>Hello</Box>`,

--- a/src/rules/no-deprecated-colors.js
+++ b/src/rules/no-deprecated-colors.js
@@ -118,11 +118,18 @@ module.exports = {
           return
         }
 
-        const [key, ...path] = node.arguments[0].value.split('.')
+        const argument = node.arguments[0]
+        // Skip if the argument is not a Literal (themeGet(props.backgroundColor))
+        // or a string themeGet(2)
+        if (argument.type !== 'Literal' || typeof argument.value !== 'string') {
+          return false
+        }
+
+        const [key, ...path] = argument.value.split('.')
         const name = path.join('.')
 
         if (['colors', 'shadows'].includes(key) && Object.keys(deprecations).includes(name)) {
-          replaceDeprecatedColor(context, node.arguments[0], name, str => [key, str].join('.'))
+          replaceDeprecatedColor(context, argument, name, str => [key, str].join('.'))
         }
       }
     }

--- a/src/rules/no-deprecated-colors.js
+++ b/src/rules/no-deprecated-colors.js
@@ -122,7 +122,7 @@ module.exports = {
         // Skip if the argument is not a Literal (themeGet(props.backgroundColor))
         // or a string themeGet(2)
         if (argument.type !== 'Literal' || typeof argument.value !== 'string') {
-          return false
+          return
         }
 
         const [key, ...path] = argument.value.split('.')


### PR DESCRIPTION
When running the `no-deprecated-colors` rule, if `themeGet` was called with a non-literal argument (e.g. `themeGet(props.backgroundColorThemeValue)`, then the linter would throw an error when trying to parse the theme value, expecting it to be a string:

```
TypeError: Cannot read properties of undefined (reading 'split')
Occurred while linting /home/runner/work/memex/memex/src/client/components/memex-avatar-stack.tsx:40
Rule: "primer-react/no-deprecated-colors"
    at CallExpression (/home/runner/work/memex/memex/node_modules/eslint-plugin-primer-react/src/rules/no-deprecated-colors.js:121:56)
    at ruleErrorHandler (/home/runner/work/memex/memex/node_modules/eslint/lib/linter/linter.js:966:28)
    at /home/runner/work/memex/memex/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/home/runner/work/memex/memex/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/home/runner/work/memex/memex/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (/home/runner/work/memex/memex/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
    at NodeEventGenerator.enterNode (/home/runner/work/memex/memex/node_modules/eslint/lib/linter/node-event-generator.js:340:14)
    at CodePathAnalyzer.enterNode (/home/runner/work/memex/memex/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:795:23)
    at /home/runner/work/memex/memex/node_modules/eslint/lib/linter/linter.js:997:32
```

This PR adds a guard to return early if the argument's type is not a `Literal` or a `String`.