### PR TITLE
Update no-system-props.js to exclude IconButton size

### DIFF
--- a/src/rules/no-system-props.js
+++ b/src/rules/no-system-props.js
@@ -18,7 +18,8 @@ const excludedComponentProps = new Map([
   ['ProgressBar', new Set(['bg'])],
   ['Spinner', new Set(['size'])],
   ['StyledOcticon', new Set(['size'])],
-  ['PointerBox', new Set(['bg'])]
+  ['PointerBox', new Set(['bg'])],
+  ['IconButton', new Set(['size'])]
 ])
 
 const alwaysExcludedProps = new Set(['variant'])


### PR DESCRIPTION
Add IconButton `size` to excluded component props.

When using `IconButton` where primer/no-system-props is enabled, eslint incorrectly flags any usage of the `size` prop as an error. 