### PR TITLE
Define some component mappings for jsx-a11y

### DIFF
--- a/.changeset/popular-swans-kick.md
+++ b/.changeset/popular-swans-kick.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+Define some component mappings for jsx-a11y

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -17,6 +17,12 @@ module.exports = {
         Link: { props: { as: { undefined: 'a', 'a': 'a', 'button': 'button'}}},
         Button: { default: 'button' },
       }
+    },
+    'jsx-a11y': {
+      components: {
+        Button: 'button',
+        IconButton: 'button'
+      }
     }
   }
 }


### PR DESCRIPTION
This PR defines the component mapping for `eslint-plugin-jsx-a11y` plugin to get more linting coverage. We can define more mappings as we see fit but I think it's fine to start small for now since this feature is pretty new in `eslint-plugin-jsx-a11y`.
These PRC button components are simple and don't support `as` prop so we are able to use the [1:1 component mapping feature](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#usage) in `eslint-plugin-jsx-a11y`.

`plugin:github/react` pulls in `eslint-plugin-jsx-a11y`.

We discussed previously that it makes sense for `primer-react/recommended` to have these mappings defined so PRC consumers don't need to define their own.



