### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes should be reviewed by a member of the @react-reviewers team
+* @primer/react-reviewers


### PR DESCRIPTION
I am adding CODEOWNERS To minimize needing to manually tag people.
I think `@primer/react-reviewers`  would be most appropriate.

If someone with write permission can give  `@primer/react-reviewers` write access that will be great.