### PR TITLE
`direct-slot-children` hot fixes

### DIFF
--- a/.changeset/real-rules-count.md
+++ b/.changeset/real-rules-count.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+`direct-slot-children` fixes

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -8,14 +8,15 @@ module.exports = {
   plugins: ['primer-react', 'github'],
   extends: ['plugin:github/react'],
   rules: {
+    'primer-react/direct-slot-children': 'error',
     'primer-react/no-deprecated-colors': 'warn',
     'primer-react/no-system-props': 'warn'
   },
   settings: {
     github: {
       components: {
-        Link: { props: { as: { undefined: 'a', 'a': 'a', 'button': 'button'}}},
-        Button: { default: 'button' },
+        Link: {props: {as: {undefined: 'a', a: 'a', button: 'button'}}},
+        Button: {default: 'button'}
       }
     },
     'jsx-a11y': {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
+    'direct-slot-children': require('./rules/direct-slot-children'),
     'no-deprecated-colors': require('./rules/no-deprecated-colors'),
     'no-system-props': require('./rules/no-system-props')
   },

--- a/src/rules/__tests__/direct-slot-children.test.js
+++ b/src/rules/__tests__/direct-slot-children.test.js
@@ -15,6 +15,7 @@ ruleTester.run('direct-slot-children', rule, {
   valid: [
     `import {PageLayout} from '@primer/react'; <PageLayout><PageLayout.Header>Header</PageLayout.Header><PageLayout.Footer>Footer</PageLayout.Footer></PageLayout>`,
     `import {PageLayout} from '@primer/react'; <PageLayout><div><PageLayout.Pane>Header</PageLayout.Pane></div></PageLayout>`,
+    `import {PageLayout} from '@primer/react'; <PageLayout>{true ? <PageLayout.Header>Header</PageLayout.Header> : null}</PageLayout>`,
     `import {PageLayout} from './PageLayout'; <PageLayout.Header>Header</PageLayout.Header>`,
     {
       code: `import {Foo} from './Foo'; <Foo><div><Foo.Bar></Foo.Bar></div></Foo>`,


### PR DESCRIPTION
- Actually export the rule from `index.js`
- Revert to stack approach to handle ternaries (added a new unit test)