### PR TITLE
More direct-slot-children fixes

### DIFF
--- a/.changeset/smooth-chefs-hammer.md
+++ b/.changeset/smooth-chefs-hammer.md
@@ -1,0 +1,9 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+More `direct-slot-children` fixes:
+- Fix bug related self-closing JSX tags
+- Allow slot children to accept multiple parents (ex: `ActionList.Item` or `ActionList.LinkItem`)
+- Add `SplitPageLayout` and `NavList` to the slot map
+- Ignore `MarkdownEditor` because it's still a draft

--- a/src/rules/__tests__/direct-slot-children.test.js
+++ b/src/rules/__tests__/direct-slot-children.test.js
@@ -17,6 +17,7 @@ ruleTester.run('direct-slot-children', rule, {
     `import {PageLayout} from '@primer/react'; <PageLayout><div><PageLayout.Pane>Header</PageLayout.Pane></div></PageLayout>`,
     `import {PageLayout} from '@primer/react'; <PageLayout>{true ? <PageLayout.Header>Header</PageLayout.Header> : null}</PageLayout>`,
     `import {PageLayout} from './PageLayout'; <PageLayout.Header>Header</PageLayout.Header>`,
+    `import {FormControl, Radio} from '@primer/react'; <FormControl><Radio value="one" /><FormControl.Label>Choice one</FormControl.Label></FormControl>`,
     {
       code: `import {Foo} from './Foo'; <Foo><div><Foo.Bar></Foo.Bar></div></Foo>`,
       options: [{skipImportCheck: true}]

--- a/src/rules/__tests__/direct-slot-children.test.js
+++ b/src/rules/__tests__/direct-slot-children.test.js
@@ -18,10 +18,9 @@ ruleTester.run('direct-slot-children', rule, {
     `import {PageLayout} from '@primer/react'; <PageLayout>{true ? <PageLayout.Header>Header</PageLayout.Header> : null}</PageLayout>`,
     `import {PageLayout} from './PageLayout'; <PageLayout.Header>Header</PageLayout.Header>`,
     `import {FormControl, Radio} from '@primer/react'; <FormControl><Radio value="one" /><FormControl.Label>Choice one</FormControl.Label></FormControl>`,
-    {
-      code: `import {Foo} from './Foo'; <Foo><div><Foo.Bar></Foo.Bar></div></Foo>`,
-      options: [{skipImportCheck: true}]
-    }
+    `import {ActionList} from '@primer/react';
+    <ActionList.Item><ActionList.LeadingVisual> <Avatar src="https://github.com/mona.png" /></ActionList.LeadingVisual>mona<ActionList.Description>Monalisa Octocat</ActionList.Description></ActionList.Item>`,
+    {code: `import {Foo} from './Foo'; <Foo><div><Foo.Bar></Foo.Bar></div></Foo>`, options: [{skipImportCheck: true}]}
   ],
   invalid: [
     {

--- a/src/rules/__tests__/direct-slot-children.test.js
+++ b/src/rules/__tests__/direct-slot-children.test.js
@@ -20,6 +20,8 @@ ruleTester.run('direct-slot-children', rule, {
     `import {FormControl, Radio} from '@primer/react'; <FormControl><Radio value="one" /><FormControl.Label>Choice one</FormControl.Label></FormControl>`,
     `import {ActionList} from '@primer/react';
     <ActionList.Item><ActionList.LeadingVisual> <Avatar src="https://github.com/mona.png" /></ActionList.LeadingVisual>mona<ActionList.Description>Monalisa Octocat</ActionList.Description></ActionList.Item>`,
+    `import {ActionList} from '@primer/react';
+    <ActionList.LinkItem><ActionList.LeadingVisual></ActionList.LeadingVisual>mona<ActionList.Description>Monalisa Octocat</ActionList.Description></ActionList.LinkItem>`,
     {code: `import {Foo} from './Foo'; <Foo><div><Foo.Bar></Foo.Bar></div></Foo>`, options: [{skipImportCheck: true}]}
   ],
   invalid: [
@@ -84,6 +86,15 @@ ruleTester.run('direct-slot-children', rule, {
         {
           messageId: 'directSlotChildren',
           data: {childName: 'PageLayout.Header', parentName: 'PageLayout'}
+        }
+      ]
+    },
+    {
+      code: `import {ActionList} from '@primer/react'; <ActionList.Item><div><ActionList.LeadingVisual>Visual</ActionList.LeadingVisual></div></ActionList.Item>`,
+      errors: [
+        {
+          messageId: 'directSlotChildren',
+          data: {childName: 'ActionList.LeadingVisual', parentName: 'ActionList.Item or ActionList.LinkItem'}
         }
       ]
     }

--- a/src/rules/__tests__/direct-slot-children.test.js
+++ b/src/rules/__tests__/direct-slot-children.test.js
@@ -34,6 +34,15 @@ ruleTester.run('direct-slot-children', rule, {
       ]
     },
     {
+      code: `import {PageLayout} from '@primer/react'; function Header() { return <PageLayout.Header>Header</PageLayout.Header>; }`,
+      errors: [
+        {
+          messageId: 'directSlotChildren',
+          data: {childName: 'PageLayout.Header', parentName: 'PageLayout'}
+        }
+      ]
+    },
+    {
       code: `import {PageLayout} from '@primer/react/drafts'; <PageLayout.Header>Header</PageLayout.Header>`,
       errors: [
         {

--- a/src/rules/direct-slot-children.js
+++ b/src/rules/direct-slot-children.js
@@ -5,11 +5,12 @@ const slotParentToChildMap = {
   PageLayout: ['PageLayout.Header', 'PageLayout.Footer'],
   SplitPageLayout: ['SplitPageLayout.Header', 'SplitPageLayout.Footer'],
   FormControl: ['FormControl.Label', 'FormControl.Caption', 'FormControl.LeadingVisual', 'FormControl.TrailingVisual'],
-  MarkdownEditor: ['MarkdownEditor.Toolbar', 'MarkdownEditor.Actions', 'MarkdownEditor.Label'],
   'ActionList.Item': ['ActionList.LeadingVisual', 'ActionList.TrailingVisual', 'ActionList.Description'],
   'TreeView.Item': ['TreeView.LeadingVisual', 'TreeView.TrailingVisual'],
   RadioGroup: ['RadioGroup.Label', 'RadioGroup.Caption', 'RadioGroup.Validation'],
   CheckboxGroup: ['CheckboxGroup.Label', 'CheckboxGroup.Caption', 'CheckboxGroup.Validation']
+  // Ignore `MarkdownEditor` for now because it's still in drafts
+  // MarkdownEditor: ['MarkdownEditor.Toolbar', 'MarkdownEditor.Actions', 'MarkdownEditor.Label'],
 }
 
 const slotChildToParentMap = Object.entries(slotParentToChildMap).reduce((acc, [parent, children]) => {

--- a/src/rules/direct-slot-children.js
+++ b/src/rules/direct-slot-children.js
@@ -3,6 +3,7 @@ const {last} = require('lodash')
 
 const slotParentToChildMap = {
   PageLayout: ['PageLayout.Header', 'PageLayout.Footer'],
+  SplitPageLayout: ['SplitPageLayout.Header', 'SplitPageLayout.Footer'],
   FormControl: ['FormControl.Label', 'FormControl.Caption', 'FormControl.LeadingVisual', 'FormControl.TrailingVisual'],
   MarkdownEditor: ['MarkdownEditor.Toolbar', 'MarkdownEditor.Actions', 'MarkdownEditor.Label'],
   'ActionList.Item': ['ActionList.LeadingVisual', 'ActionList.TrailingVisual', 'ActionList.Description'],

--- a/src/rules/direct-slot-children.js
+++ b/src/rules/direct-slot-children.js
@@ -6,6 +6,7 @@ const slotParentToChildMap = {
   SplitPageLayout: ['SplitPageLayout.Header', 'SplitPageLayout.Footer'],
   FormControl: ['FormControl.Label', 'FormControl.Caption', 'FormControl.LeadingVisual', 'FormControl.TrailingVisual'],
   'ActionList.Item': ['ActionList.LeadingVisual', 'ActionList.TrailingVisual', 'ActionList.Description'],
+  'ActionList.LinkItem': ['ActionList.LeadingVisual', 'ActionList.TrailingVisual', 'ActionList.Description'],
   'NavList.Item': ['NavList.LeadingVisual', 'NavList.TrailingVisual'],
   'TreeView.Item': ['TreeView.LeadingVisual', 'TreeView.TrailingVisual'],
   RadioGroup: ['RadioGroup.Label', 'RadioGroup.Caption', 'RadioGroup.Validation'],
@@ -16,7 +17,11 @@ const slotParentToChildMap = {
 
 const slotChildToParentMap = Object.entries(slotParentToChildMap).reduce((acc, [parent, children]) => {
   for (const child of children) {
-    acc[child] = parent
+    if (acc[child]) {
+      acc[child].push(parent)
+    } else {
+      acc[child] = [parent]
+    }
   }
   return acc
 }, {})
@@ -53,13 +58,16 @@ module.exports = {
           (skipImportCheck || isPrimerComponent(jsxNode.name, context.getScope(jsxNode))) &&
           slotChildToParentMap[name]
         ) {
-          const expectedParentName = slotChildToParentMap[name]
+          const expectedParentNames = slotChildToParentMap[name]
           const parent = last(stack)
-          if (parent !== expectedParentName) {
+          if (!expectedParentNames.includes(parent)) {
             context.report({
               node: jsxNode,
               messageId: 'directSlotChildren',
-              data: {childName: name, parentName: expectedParentName}
+              data: {
+                childName: name,
+                parentName: expectedParentNames.length > 1 ? expectedParentNames.join(' or ') : expectedParentNames[0]
+              }
             })
           }
         }

--- a/src/rules/direct-slot-children.js
+++ b/src/rules/direct-slot-children.js
@@ -6,6 +6,7 @@ const slotParentToChildMap = {
   SplitPageLayout: ['SplitPageLayout.Header', 'SplitPageLayout.Footer'],
   FormControl: ['FormControl.Label', 'FormControl.Caption', 'FormControl.LeadingVisual', 'FormControl.TrailingVisual'],
   'ActionList.Item': ['ActionList.LeadingVisual', 'ActionList.TrailingVisual', 'ActionList.Description'],
+  'NavList.Item': ['NavList.LeadingVisual', 'NavList.TrailingVisual'],
   'TreeView.Item': ['TreeView.LeadingVisual', 'TreeView.TrailingVisual'],
   RadioGroup: ['RadioGroup.Label', 'RadioGroup.Caption', 'RadioGroup.Validation'],
   CheckboxGroup: ['CheckboxGroup.Label', 'CheckboxGroup.Caption', 'CheckboxGroup.Validation']

--- a/src/rules/direct-slot-children.js
+++ b/src/rules/direct-slot-children.js
@@ -61,8 +61,10 @@ module.exports = {
           }
         }
 
-        // Push the current element onto the stack
-        stack.push(name)
+        // If tag is not self-closing, push it onto the stack
+        if (!jsxNode.selfClosing) {
+          stack.push(name)
+        }
       },
       JSXClosingElement() {
         // Pop the current element off the stack


### PR DESCRIPTION
- Fix bug related self-closing JSX tags
- Allow slot children to accept multiple parents (ex: `ActionList.Item` or `ActionList.LinkItem`)
- Add `SplitPageLayout` and `NavList` to the slot map
- Ignore `MarkdownEditor` because it's still a draft
