### PR TITLE
Add dependabot.yml to ensure dependencies are up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,4 @@ updates:
     open-pull-requests-limit: 99
     allow: 
       - "eslint-plugin-github"
+      - "eslint-plugin-jsx-a11y"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,5 @@ updates:
       interval: weekly
     open-pull-requests-limit: 99
     allow: 
-      - "eslint-plugin-github"
-      - "eslint-plugin-jsx-a11y"
+      - dependency-name: "eslint-plugin-github"
+      - dependency-name: "eslint-plugin-jsx-a11y"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,5 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
-  - package-ecosystem: github-actions
-    directory: '/'
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 99
+    allow: 
+      - "eslint-plugin-github"


### PR DESCRIPTION
We should keep the `eslint-plugin-github` and `eslint-plugin-jsx-a11y` version up-to-date.