### PR TITLE
Feedback needed: Lint rule to warn against deprecated component usages across dotcom

### DIFF
--- a/src/rules/__tests__/no-deprecated-components.js
+++ b/src/rules/__tests__/no-deprecated-components.js
@@ -1,0 +1,34 @@
+const rule = require('../no-deprecated-components')
+const {RuleTester} = require('eslint')
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+})
+
+ruleTester.run('no-deprecated-components', rule, {
+  valid: [`import {ActionList} from '@primer/react';`, `import {Tooltip} from '@primer/react/experimental';`],
+  invalid: [
+    {
+      code: `import {ActionList} from '@primer/react/deprecated';`,
+      errors: [
+        {
+          messageId: 'deprecatedComponent'
+        }
+      ]
+    },
+    {
+      code: `import {Tooltip} from '@primer/react';`,
+      errors: [
+        {
+          messageId: 'toBeDeprecatedComponent'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
DISREGARD IT FOR NOW - WILL BRING IT TO THE ENG SYNC FIRST

https://github.com/primer/eslint-plugin-primer-react/issues/59

To increase the adoption of our accessible/improved components, we want to add a lint rule that warns consumers if they stay using the deprecated version of the components. Currently I think of 2 possible usages.

### Imported from the deprecated bundle

Encourage ActionList usage from 
```
import { ActionList } from '@primer/react/deprecated'
```
to
```
import { ActionList } from '@primer/react'
```


### Imported from the main bundle but has a `@deprecated` annotation 
Encourage Tooltip usage from 
```
import { Tooltip } from '@primer/react'
```
to
```
import { Tooltip } from '@primer/react/experimental'
```

