### PR TITLE
Add `MarkdownEditor.Footer` support in `direct-slot-children` rule

### DIFF
--- a/.changeset/soft-bees-explain.md
+++ b/.changeset/soft-bees-explain.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-primer-react': patch
+---
+
+Adds support for `MarkdownEditor.Footer` in `direct-slot-children` rule

--- a/src/rules/__tests__/direct-slot-children.test.js
+++ b/src/rules/__tests__/direct-slot-children.test.js
@@ -22,6 +22,8 @@ ruleTester.run('direct-slot-children', rule, {
     <ActionList.Item><ActionList.LeadingVisual> <Avatar src="https://github.com/mona.png" /></ActionList.LeadingVisual>mona<ActionList.Description>Monalisa Octocat</ActionList.Description></ActionList.Item>`,
     `import {ActionList} from '@primer/react';
     <ActionList.LinkItem><ActionList.LeadingVisual></ActionList.LeadingVisual>mona<ActionList.Description>Monalisa Octocat</ActionList.Description></ActionList.LinkItem>`,
+    `import {MarkdownEditor} from '@primer/react'; <MarkdownEditor><MarkdownEditor.Footer><MarkdownEditor.Actions></MarkdownEditor.Actions></MarkdownEditor.Footer></MarkdownEditor>`,
+    `import {MarkdownEditor} from '@primer/react'; <MarkdownEditor><MarkdownEditor.Footer><MarkdownEditor.FooterButton></MarkdownEditor.FooterButton></MarkdownEditor.Footer></MarkdownEditor>`,
     {code: `import {Foo} from './Foo'; <Foo><div><Foo.Bar></Foo.Bar></div></Foo>`, options: [{skipImportCheck: true}]}
   ],
   invalid: [
@@ -95,6 +97,24 @@ ruleTester.run('direct-slot-children', rule, {
         {
           messageId: 'directSlotChildren',
           data: {childName: 'ActionList.LeadingVisual', parentName: 'ActionList.Item or ActionList.LinkItem'}
+        }
+      ]
+    },
+    {
+      code: `import {MarkdownEditor} from '@primer/react'; <MarkdownEditor><div><MarkdownEditor.Actions></MarkdownEditor.Actions></div></MarkdownEditor>`,
+      errors: [
+        {
+          messageId: 'directSlotChildren',
+          data: {childName: 'MarkdownEditor.Actions', parentName: 'MarkdownEditor or MarkdownEditor.Footer'}
+        }
+      ]
+    },
+    {
+      code: `import {MarkdownEditor} from '@primer/react'; <MarkdownEditor><MarkdownEditor.FooterButton></MarkdownEditor.FooterButton></MarkdownEditor>`,
+      errors: [
+        {
+          messageId: 'directSlotChildren',
+          data: {childName: 'MarkdownEditor.FooterButton', parentName: 'MarkdownEditor.Footer'}
         }
       ]
     }

--- a/src/rules/direct-slot-children.js
+++ b/src/rules/direct-slot-children.js
@@ -12,7 +12,8 @@ const slotParentToChildMap = {
   'TreeView.Item': ['TreeView.LeadingVisual', 'TreeView.TrailingVisual'],
   RadioGroup: ['RadioGroup.Label', 'RadioGroup.Caption', 'RadioGroup.Validation'],
   CheckboxGroup: ['CheckboxGroup.Label', 'CheckboxGroup.Caption', 'CheckboxGroup.Validation'],
-  MarkdownEditor: ['MarkdownEditor.Toolbar', 'MarkdownEditor.Actions', 'MarkdownEditor.Label']
+  MarkdownEditor: ['MarkdownEditor.Toolbar', 'MarkdownEditor.Actions', 'MarkdownEditor.Label'],
+  'MarkdownEditor.Footer': ['MarkdownEditor.Actions', 'MarkdownEditor.FooterButton']
 }
 
 const slotChildToParentMap = Object.entries(slotParentToChildMap).reduce((acc, [parent, children]) => {


### PR DESCRIPTION
## Summary 
Adds support for `MarkdownEditor.Footer`.

`MarkdownEditor.Footer` was recently added to the `MarkdownEditor` component and the `direct-slot-children` rule has not yet been updated to reflect that. This PR adds support for `MarkdownEditor.Actions` and `MarkdownEditor.FooterButton` under `MarkdownEditor.Footer`.