### PR TITLE
fix(rules): update no-system-props to include Blankslate

### DIFF
--- a/.changeset/six-pumas-live.md
+++ b/.changeset/six-pumas-live.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+Update the no-system-props rule to exclude the `border` prop for the `Blankslate` component from `@primer/react`.

--- a/src/rules/no-system-props.js
+++ b/src/rules/no-system-props.js
@@ -18,6 +18,7 @@ const excludedComponentProps = new Map([
   ['AnchoredOverlay', new Set(['width', 'height'])],
   ['Avatar', new Set(['size'])],
   ['AvatarToken', new Set(['size'])],
+  ['Blankslate', new Set(['border'])],
   ['CircleOcticon', new Set(['size'])],
   ['Dialog', new Set(['width', 'height'])],
   ['IssueLabelToken', new Set(['size'])],


### PR DESCRIPTION
The `Blankslate` component currently supports a `border` prop that is not considered a system prop. This PR adds Blankslate to the list of excluded component props for this rule.