### PR TITLE
Remove one instance of eslint-plugin-github from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@styled-system/props": "^5.1.5",
-        "eslint-plugin-github": "^4.9.2",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-traverse": "^1.0.0",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "@styled-system/props": "^5.1.5",
-    "eslint-plugin-github": "^4.9.2",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-traverse": "^1.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
The CI failing on the latest dependabot update is complaining that different versions of `eslint-plugin-github` are present in `dependencies` and `devDependencies` of the package. I think the latest in `devDependencies` should be sufficient.