### PR TITLE
ci(release): add concurrency group Release canary workflow

### DIFF
--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -5,10 +5,13 @@ on:
       - 'main'
       - 'changeset-release/main'
 
+concurrency:
+  group: npm-canary
+  cancel-in-progress: false
+
 jobs:
   release:
     if: ${{ github.repository == 'primer/eslint-plugin-primer-react' }}
-
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Add a [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) group so that only one `release_canary` workflow run happens at a time. This should help with conflicting publishes for canary versions for PRs from things like dependabot or if PRs are opened within a similar time window.