### PR TITLE
feat(rules): add no-deprecated-entrypoints rule

### DIFF
--- a/.changeset/big-bananas-teach.md
+++ b/.changeset/big-bananas-teach.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-primer-react': minor
+---
+
+Add no-deprecated-entrypoints rule to lint against deprecated import usage in @primer/react

--- a/docs/rules/no-deprecated-entrypoints.md
+++ b/docs/rules/no-deprecated-entrypoints.md
@@ -7,10 +7,10 @@ This rule enforces the usage of non-deprecated entrypoints from `@primer/react`.
 👎 Examples of **incorrect** code for this rule
 
 ```jsx
-import {ExampleComponent} from '@primer/react/drafts'
+import {DataTable} from '@primer/react/drafts'
 
 function ExampleComponent() {
-  return <SSRProvider>...</SSRProvider>
+  return <DataTable>{/* ... */}</DataTable>
 }
 ```
 
@@ -20,6 +20,6 @@ function ExampleComponent() {
 import {ExampleComponent} from '@primer/react/experimental'
 
 function ExampleComponent() {
-  return <Button>...</Button>
+  return <DataTable>{/* ... */}</DataTable>
 }
 ```

--- a/docs/rules/no-deprecated-entrypoints.md
+++ b/docs/rules/no-deprecated-entrypoints.md
@@ -1,0 +1,25 @@
+# No Deprecated Entrypoints
+
+## Rule Details
+
+This rule enforces the usage of non-deprecated entrypoints from `@primer/react`.
+
+👎 Examples of **incorrect** code for this rule
+
+```jsx
+import {ExampleComponent} from '@primer/react/drafts'
+
+function ExampleComponent() {
+  return <SSRProvider>...</SSRProvider>
+}
+```
+
+👍 Examples of **correct** code for this rule:
+
+```jsx
+import {ExampleComponent} from '@primer/react/experimental'
+
+function ExampleComponent() {
+  return <Button>...</Button>
+}
+```

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ module.exports = {
   rules: {
     'direct-slot-children': require('./rules/direct-slot-children'),
     'no-deprecated-colors': require('./rules/no-deprecated-colors'),
+    'no-deprecated-entrypoints': require('./rules/no-deprecated-entrypoints'),
     'no-system-props': require('./rules/no-system-props'),
     'a11y-tooltip-interactive-trigger': require('./rules/a11y-tooltip-interactive-trigger'),
     'new-color-css-vars': require('./rules/new-color-css-vars'),

--- a/src/rules/__tests__/no-deprecated-entrypoints.test.js
+++ b/src/rules/__tests__/no-deprecated-entrypoints.test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const {RuleTester} = require('eslint')
+const rule = require('../no-deprecated-entrypoints')
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+})
+
+ruleTester.run('no-deprecated-entrypoints', rule, {
+  valid: [`import {Box} from '@primer/react';`],
+  invalid: [
+    {
+      code: `import {DataTable} from '@primer/react/drafts';`,
+      output: `import {DataTable} from '@primer/react/experimental';`,
+      errors: [
+        {
+          message:
+            'The drafts entrypoint is deprecated and will be removed in the next major release. Use the experimental entrypoint instead',
+        },
+      ],
+    },
+  ],
+})

--- a/src/rules/no-deprecated-entrypoints.js
+++ b/src/rules/no-deprecated-entrypoints.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const url = require('../url')
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Avoid using deprecated entrypoints from @primer/react',
+      recommended: true,
+      url: url(module),
+    },
+    fixable: true,
+    schema: [],
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === '@primer/react/drafts') {
+          context.report({
+            node,
+            message:
+              'The drafts entrypoint is deprecated and will be removed in the next major release. Use the experimental entrypoint instead',
+            fix(fixer) {
+              return fixer.replaceText(node.source, `'@primer/react/experimental'`)
+            },
+          })
+        }
+      },
+    }
+  },
+}


### PR DESCRIPTION
Add the `no-deprecated-entrypoints` rule to lint against using deprecated entrypoints and provide a fixer to correct usage.