### PR TITLE
no-system-props: Add alignContent to allowed props for Button

### DIFF
--- a/.changeset/slimy-laws-refuse.md
+++ b/.changeset/slimy-laws-refuse.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+no-system-props: Add alignContent to allowed props for Button

--- a/src/rules/no-system-props.js
+++ b/src/rules/no-system-props.js
@@ -19,6 +19,7 @@ const excludedComponentProps = new Map([
   ['Avatar', new Set(['size'])],
   ['AvatarToken', new Set(['size'])],
   ['Blankslate', new Set(['border'])],
+  ['Button', new Set(['alignContent'])],
   ['CircleOcticon', new Set(['size'])],
   ['Dialog', new Set(['width', 'height'])],
   ['IssueLabelToken', new Set(['size'])],


### PR DESCRIPTION
- Fixes https://github.com/primer/react/issues/4115