### PR TITLE
no-system-props: allow maxWidth prop for Truncate

### DIFF
--- a/.changeset/lazy-planes-prove.md
+++ b/.changeset/lazy-planes-prove.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+no-system-props: allow maxWidth prop for Truncate

--- a/src/rules/no-system-props.js
+++ b/src/rules/no-system-props.js
@@ -42,6 +42,7 @@ const excludedComponentProps = new Map([
   ['PageLayout.Content', new Set(['padding', 'width'])],
   ['ProgressBar', new Set(['bg'])],
   ['PointerBox', new Set(['bg'])],
+  ['Truncate', new Set(['maxWidth'])],
 ])
 
 const alwaysExcludedProps = new Set(['variant', 'size'])


### PR DESCRIPTION
`maxWidth` is a valid prop for https://primer.style/components/truncate/react/alpha