### PR TITLE
no-system-props: allow color & size for Octicon

### DIFF
--- a/src/rules/no-system-props.js
+++ b/src/rules/no-system-props.js
@@ -32,8 +32,7 @@ const excludedComponentProps = new Map([
   ['SplitPageLayout.Pane', new Set(['padding', 'position', 'width'])],
   ['SplitPageLayout.Content', new Set(['padding', 'width'])],
   ['StyledOcticon', new Set(['size'])],
-  ['Octicon', new Set(['color'])],
-  no-system-props: allow maxWidth prop for Truncate
+  ['Octicon', new Set(['size', 'color'])],
   ['PointerBox', new Set(['bg'])],
   ['TextInput', new Set(['size'])],
   ['TextInputWithTokens', new Set(['size', 'maxHeight'])],

--- a/src/rules/no-system-props.js
+++ b/src/rules/no-system-props.js
@@ -32,6 +32,8 @@ const excludedComponentProps = new Map([
   ['SplitPageLayout.Pane', new Set(['padding', 'position', 'width'])],
   ['SplitPageLayout.Content', new Set(['padding', 'width'])],
   ['StyledOcticon', new Set(['size'])],
+  ['Octicon', new Set(['color'])],
+  no-system-props: allow maxWidth prop for Truncate
   ['PointerBox', new Set(['bg'])],
   ['TextInput', new Set(['size'])],
   ['TextInputWithTokens', new Set(['size', 'maxHeight'])],


### PR DESCRIPTION
These are valid props: https://primer.style/components/icon/react/alpha