### PR TITLE
no-system-props: Add option to ignore specific component names

### DIFF
--- a/.changeset/quiet-poets-rescue.md
+++ b/.changeset/quiet-poets-rescue.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+no-system-props: Add ability to ignore specific component names

--- a/.changeset/quiet-poets-rescue.md
+++ b/.changeset/quiet-poets-rescue.md
@@ -2,4 +2,4 @@
 "eslint-plugin-primer-react": patch
 ---
 
-no-system-props: Add ability to ignore specific component names
+no-system-props: Add option to ignore specific component names

--- a/src/rules/__tests__/no-system-props.test.js
+++ b/src/rules/__tests__/no-system-props.test.js
@@ -23,6 +23,11 @@ ruleTester.run('no-system-props', rule, {
     `import {Button} from '@primer/react'; <Button size="large" />`,
     `import {ActionMenu} from '@primer/react'; <ActionMenu.Overlay width="large" />`,
     {code: `<img width="200px" />`, options: [{skipImportCheck: true}]},
+    {code: `<Placeholder width="200px" />`, options: [{skipImportCheck: true, ignoreNames: ['Placeholder']}]},
+    {
+      code: `<Placeholder.Header width="200px" />`,
+      options: [{skipImportCheck: true, ignoreNames: ['Placeholder.Header']}],
+    },
   ],
   invalid: [
     {

--- a/src/rules/no-system-props.js
+++ b/src/rules/no-system-props.js
@@ -55,12 +55,9 @@ module.exports = {
     schema: [
       {
         properties: {
-          skipImportCheck: {
-            type: 'boolean',
-          },
-          includeUtilityComponents: {
-            type: 'boolean',
-          },
+          skipImportCheck: {type: 'boolean'},
+          includeUtilityComponents: {type: 'boolean'},
+          ignoreNames: {type: 'array'},
         },
       },
     ],
@@ -72,8 +69,8 @@ module.exports = {
     // If `skipImportCheck` is true, this rule will check for deprecated styled system props
     // used in any components (not just ones that are imported from `@primer/react`).
     const skipImportCheck = context.options[0] ? context.options[0].skipImportCheck : false
-
     const includeUtilityComponents = context.options[0] ? context.options[0].includeUtilityComponents : false
+    const ignoreNames = context.options[0] ? context.options[0].ignoreNames || [] : []
 
     const excludedComponents = new Set([
       ...alwaysExcludedComponents,
@@ -92,6 +89,7 @@ module.exports = {
         }
 
         const componentName = getJSXOpeningElementName(jsxNode)
+        if (ignoreNames.length && ignoreNames.includes(componentName)) return
 
         if (excludedComponents.has(componentName)) return
 


### PR DESCRIPTION
Useful for linting primer/react internally.

An example from the docs:

```jsx
<Hidden when={['narrow', 'wide']}>
  <Placeholder height="80px" label="This is not visible in narrow and wide viewport" />
</Hidden>
```

Placeholder is not an exported component and we'd not want to add an eslint-ignore inside the docs.