### PR TITLE
Add `no-deprecated-props` rule

### DIFF
--- a/.changeset/tidy-moons-sip.md
+++ b/.changeset/tidy-moons-sip.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-primer-react': minor
+---
+
+Add no-deprecated-props rule

--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ ESLint rules for Primer React
 - [a11y-tooltip-interactive-trigger](https://github.com/primer/eslint-plugin-primer-react/blob/main/docs/rules/a11y-tooltip-interactive-trigger.md)
 - [a11y-explicit-heading](https://github.com/primer/eslint-plugin-primer-react/blob/main/docs/rules/a11y-explicit-heading.md)
 - [new-css-color-vars](https://github.com/primer/eslint-plugin-primer-react/blob/main/docs/rules/new-css-color-vars.md)
+- [no-deprecated-props](https://github.com/primer/eslint-plugin-primer-react/blob/main/docs/rules/no-deprecated-props.md)

--- a/docs/rules/no-deprecated-props.md
+++ b/docs/rules/no-deprecated-props.md
@@ -1,0 +1,48 @@
+## Rule Details
+
+This rule enforces to use the recommended API (`ActionList.GroupHeading`) component over the deprecated prop (`title` prop on `ActionList.Group`) for ActionList component.
+
+👎 Examples of **incorrect** code for this rule:
+
+```jsx
+/* eslint primer-react/no-deprecated-props: "error" */
+import {ActionList} from '@primer/react'
+
+const App = () => (
+  <ActionList>
+    <ActionList.Group title="Group heading">
+      <ActionList.Item>Item 1</ActionList.Item>
+    </ActionList.Group>
+  </ActionList>
+)
+```
+
+👍 Examples of **correct** code for this rule:
+
+```jsx
+/* eslint primer-react/no-deprecated-props: "error" */
+import {ActionList} from '@primer/react'
+
+const App = () => (
+  <ActionList>
+    <ActionList.Group>
+      <ActionList.GroupHeading as="h2">Group heading</ActionList.GroupHeading>
+      <ActionList.Item>Item 1</ActionList.Item>
+    </ActionList.Group>
+  </ActionList>
+)
+```
+
+```jsx
+/* eslint primer-react/no-deprecated-props: "error" */
+import {ActionList} from '@primer/react'
+
+const App = () => (
+  <ActionList role="lisbox">
+    <ActionList.Group>
+      <ActionList.GroupHeading>Group heading</ActionList.GroupHeading>
+      <ActionList.Item>Item 1</ActionList.Item>
+    </ActionList.Group>
+  </ActionList>
+)
+```

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -17,6 +17,7 @@ module.exports = {
     'primer-react/new-color-css-vars': 'error',
     'primer-react/a11y-explicit-heading': 'error',
     'primer-react/new-color-css-vars-have-fallback': 'error',
+    'primer-react/no-deprecated-props': 'warn',
   },
   settings: {
     github: {

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ module.exports = {
     'new-color-css-vars': require('./rules/new-color-css-vars'),
     'a11y-explicit-heading': require('./rules/a11y-explicit-heading'),
     'new-color-css-vars-have-fallback': require('./rules/new-color-css-vars-have-fallback'),
+    'no-deprecated-props': require('./rules/no-deprecated-props'),
   },
   configs: {
     recommended: require('./configs/recommended'),

--- a/src/rules/__tests__/no-deprecated-props.test.js
+++ b/src/rules/__tests__/no-deprecated-props.test.js
@@ -1,0 +1,99 @@
+'use strict'
+
+const {RuleTester} = require('eslint')
+const rule = require('../no-deprecated-props')
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+})
+
+ruleTester.run('no-deprecated-props', rule, {
+  valid: [
+    `import {ActionList} from '@primer/react';
+    <ActionList>
+        <ActionList.Group>
+            <ActionList.GroupHeading as="h3">Group heading 1</ActionList.GroupHeading>
+            <ActionList.Item>Item</ActionList.Item>
+        </ActionList.Group>
+        <ActionList.Group>
+            <ActionList.GroupHeading as="h3">Group heading 2</ActionList.GroupHeading>
+            <ActionList.Item>Item 2</ActionList.Item>
+        </ActionList.Group>
+    </ActionList>`,
+    `import {ActionList} from '@primer/react';
+    <ActionList>
+        <ActionList.Group>
+            <ActionList.GroupHeading>Group heading 1</ActionList.GroupHeading>
+            <ActionList.Item>Item</ActionList.Item>
+        </ActionList.Group>
+        <ActionList.Group>
+            <ActionList.GroupHeading>Group heading 2</ActionList.GroupHeading>
+            <ActionList.Item>Item 2</ActionList.Item>
+        </ActionList.Group>
+    </ActionList>`,
+    `import {ActionList} from '@primer/react';
+    <ActionList>
+        <ActionList.Group>
+            <ActionList.GroupHeading as="h3">Group heading</ActionList.GroupHeading>
+            <ActionList.Item>Item</ActionList.Item>
+        </ActionList.Group>
+        <ActionList.Item>Item 2</ActionList.Item>
+    </ActionList>`,
+    `import {ActionList} from '@primer/react';
+    <ActionList role="listbox">
+        <ActionList.Group>
+            <ActionList.GroupHeading>Group heading</ActionList.GroupHeading>
+            <ActionList.Item>Item</ActionList.Item>
+        </ActionList.Group>
+        <ActionList.Item>Item 2</ActionList.Item>
+    </ActionList>`,
+    `import {ActionList} from '@primer/react';
+    <ActionList role="menu">
+        <ActionList.Item>Item</ActionList.Item>
+        <ActionList.Group>
+            <ActionList.GroupHeading>Group heading</ActionList.GroupHeading>
+            <ActionList.Item>Group item</ActionList.Item>
+        </ActionList.Group>
+    </ActionList>`,
+  ],
+  invalid: [
+    {
+      code: `
+        import {ActionList} from '@primer/react';
+        <ActionList>
+            <ActionList.Group title="Group heading 1">
+                <ActionList.Item>Item</ActionList.Item>
+            </ActionList.Group>
+            <ActionList.Group title="Group heading 2">
+                <ActionList.Item>Item 2</ActionList.Item>
+            </ActionList.Group>
+        </ActionList>`,
+      output: `
+        import {ActionList} from '@primer/react';
+        <ActionList>
+            <ActionList.Group>
+                <ActionList.GroupHeading>Group heading 1</ActionList.GroupHeading>
+                <ActionList.Item>Item</ActionList.Item>
+            </ActionList.Group>
+            <ActionList.Group>
+                <ActionList.GroupHeading>Group heading 2</ActionList.GroupHeading>
+                <ActionList.Item>Item 2</ActionList.Item>
+            </ActionList.Group>
+        </ActionList>`,
+      errors: [
+        {
+          messageId: 'titlePropDeprecated',
+        },
+        {
+          messageId: 'titlePropDeprecated',
+        },
+      ],
+    },
+  ],
+})

--- a/src/rules/__tests__/no-deprecated-props.test.js
+++ b/src/rules/__tests__/no-deprecated-props.test.js
@@ -64,32 +64,27 @@ ruleTester.run('no-deprecated-props', rule, {
   ],
   invalid: [
     {
-      code: `
-        import {ActionList} from '@primer/react';
-        <ActionList>
-            <ActionList.Group title="Group heading 1">
-                <ActionList.Item>Item</ActionList.Item>
-            </ActionList.Group>
-            <ActionList.Group title="Group heading 2">
-                <ActionList.Item>Item 2</ActionList.Item>
-            </ActionList.Group>
-        </ActionList>`,
-      output: `
-        import {ActionList} from '@primer/react';
-        <ActionList>
-            <ActionList.Group>
-                <ActionList.GroupHeading>Group heading 1</ActionList.GroupHeading>
-                <ActionList.Item>Item</ActionList.Item>
-            </ActionList.Group>
-            <ActionList.Group>
-                <ActionList.GroupHeading>Group heading 2</ActionList.GroupHeading>
-                <ActionList.Item>Item 2</ActionList.Item>
-            </ActionList.Group>
-        </ActionList>`,
+      code: `<ActionList.Group title="Group heading 1"></ActionList.Group>`,
+      output: `<ActionList.Group><ActionList.GroupHeading>Group heading 1</ActionList.GroupHeading></ActionList.Group>`,
       errors: [
         {
           messageId: 'titlePropDeprecated',
         },
+      ],
+    },
+    {
+      code: `<ActionList.Group title="Group heading 1" sx={{padding: 2}}></ActionList.Group>`,
+      output: `<ActionList.Group sx={{padding: 2}}><ActionList.GroupHeading>Group heading 1</ActionList.GroupHeading></ActionList.Group>`,
+      errors: [
+        {
+          messageId: 'titlePropDeprecated',
+        },
+      ],
+    },
+    {
+      code: `<ActionList.Group variant="filled" title="Group heading 1"></ActionList.Group>`,
+      output: `<ActionList.Group variant="filled"><ActionList.GroupHeading>Group heading 1</ActionList.GroupHeading></ActionList.Group>`,
+      errors: [
         {
           messageId: 'titlePropDeprecated',
         },

--- a/src/rules/__tests__/no-deprecated-props.test.js
+++ b/src/rules/__tests__/no-deprecated-props.test.js
@@ -90,5 +90,32 @@ ruleTester.run('no-deprecated-props', rule, {
         },
       ],
     },
+    {
+      code: `<ActionList.Group title={title}></ActionList.Group>`,
+      output: `<ActionList.Group><ActionList.GroupHeading>{title}</ActionList.GroupHeading></ActionList.Group>`,
+      errors: [
+        {
+          messageId: 'titlePropDeprecated',
+        },
+      ],
+    },
+    {
+      code: `<ActionList.Group title={'Title'}></ActionList.Group>`,
+      output: `<ActionList.Group><ActionList.GroupHeading>Title</ActionList.GroupHeading></ActionList.Group>`,
+      errors: [
+        {
+          messageId: 'titlePropDeprecated',
+        },
+      ],
+    },
+    {
+      code: `<ActionList.Group title={condition ? 'Title' : undefined}></ActionList.Group>`,
+      output: `<ActionList.Group><ActionList.GroupHeading>Group heading 1</ActionList.GroupHeading></ActionList.Group>`,
+      errors: [
+        {
+          messageId: 'titlePropDeprecated',
+        },
+      ],
+    },
   ],
 })

--- a/src/rules/__tests__/no-deprecated-props.test.js
+++ b/src/rules/__tests__/no-deprecated-props.test.js
@@ -91,8 +91,8 @@ ruleTester.run('no-deprecated-props', rule, {
       ],
     },
     {
-      code: `<ActionList.Group title={title}></ActionList.Group>`,
-      output: `<ActionList.Group><ActionList.GroupHeading>{title}</ActionList.GroupHeading></ActionList.Group>`,
+      code: `<ActionList.Group title={titleVariable}></ActionList.Group>`,
+      output: `<ActionList.Group><ActionList.GroupHeading>{titleVariable}</ActionList.GroupHeading></ActionList.Group>`,
       errors: [
         {
           messageId: 'titlePropDeprecated',
@@ -101,7 +101,7 @@ ruleTester.run('no-deprecated-props', rule, {
     },
     {
       code: `<ActionList.Group title={'Title'}></ActionList.Group>`,
-      output: `<ActionList.Group><ActionList.GroupHeading>Title</ActionList.GroupHeading></ActionList.Group>`,
+      output: `<ActionList.Group><ActionList.GroupHeading>{'Title'}</ActionList.GroupHeading></ActionList.Group>`,
       errors: [
         {
           messageId: 'titlePropDeprecated',
@@ -110,7 +110,7 @@ ruleTester.run('no-deprecated-props', rule, {
     },
     {
       code: `<ActionList.Group title={condition ? 'Title' : undefined}></ActionList.Group>`,
-      output: `<ActionList.Group><ActionList.GroupHeading>Group heading 1</ActionList.GroupHeading></ActionList.Group>`,
+      output: `<ActionList.Group><ActionList.GroupHeading>{condition ? 'Title' : undefined}</ActionList.GroupHeading></ActionList.Group>`,
       errors: [
         {
           messageId: 'titlePropDeprecated',

--- a/src/rules/no-deprecated-props.js
+++ b/src/rules/no-deprecated-props.js
@@ -29,22 +29,20 @@ module.exports = {
           return
         }
         const title = getJSXOpeningElementAttribute(node, 'title')
+
         if (title !== undefined) {
-          console.log('hello', title.name.name, title.value.value)
           context.report({
             node,
             messageId: 'titlePropDeprecated',
             fix(fixer) {
               const groupTitle = title.value.value
-              // const sourceCode = context.sourceCode
-              // const start = title.range[0]
-              // const end = sourceCode.getTokenAfter(title).range[1]
+              const start = title.range[0]
+              const end = title.range[1]
               return [
-                // fixer.removeRange([start, end]),
-                fixer.remove(title),
+                fixer.removeRange([start - 1, end]), // remove the space before the title as well
                 fixer.insertTextAfterRange(
                   [node.range[1], node.range[1]],
-                  `\n<ActionList.GroupHeading>${groupTitle}</ActionList.GroupHeading>;`,
+                  `<ActionList.GroupHeading>${groupTitle}</ActionList.GroupHeading>`,
                 ),
               ]
             },

--- a/src/rules/no-deprecated-props.js
+++ b/src/rules/no-deprecated-props.js
@@ -29,13 +29,22 @@ module.exports = {
           return
         }
         const title = getJSXOpeningElementAttribute(node, 'title')
-
+        let groupTitle = ''
         if (title !== undefined) {
           context.report({
             node,
             messageId: 'titlePropDeprecated',
             fix(fixer) {
-              const groupTitle = title.value.value
+              // Group title is a string literal i.e. title="title"
+              if (title.value.type === 'Literal') {
+                groupTitle = title.value.value
+                // Group title is a JSX expression i.e. title={title}
+              } else if (title.value.type === 'JSXExpressionContainer') {
+                groupTitle = context.sourceCode.getText(title.value)
+              } else {
+                // we don't provide fix for cases where the title prop is not a string literal or JSX expression
+                return []
+              }
               const start = title.range[0]
               const end = title.range[1]
               return [

--- a/src/rules/no-deprecated-props.js
+++ b/src/rules/no-deprecated-props.js
@@ -2,20 +2,19 @@
 const {getJSXOpeningElementAttribute} = require('../utils/get-jsx-opening-element-attribute')
 const {getJSXOpeningElementName} = require('../utils/get-jsx-opening-element-name')
 
-const url = require('../url')
-
 /**
  * @type {import('eslint').Rule.RuleModule}
  */
 module.exports = {
   meta: {
-    type: 'problem',
+    type: 'suggestion',
     docs: {
-      description: 'Avoid using deprecated props from @primer/react',
+      description:
+        'Avoid using deprecated `title` prop on `ActionList.Group` component. Use `ActionList.GroupHeading` instead.',
       recommended: true,
-      url: url(module),
+      url: 'https://primer.style/components/action-list/react/beta#actionlistgroupheading',
     },
-    fixable: true,
+    fixable: 'code',
     schema: [],
     messages: {
       titlePropDeprecated: 'The `title` prop is deprecated. Please use `ActionList.GroupHeading` instead.',

--- a/src/rules/no-deprecated-props.js
+++ b/src/rules/no-deprecated-props.js
@@ -1,0 +1,56 @@
+'use strict'
+const {getJSXOpeningElementAttribute} = require('../utils/get-jsx-opening-element-attribute')
+const {getJSXOpeningElementName} = require('../utils/get-jsx-opening-element-name')
+
+const url = require('../url')
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Avoid using deprecated props from @primer/react',
+      recommended: true,
+      url: url(module),
+    },
+    fixable: true,
+    schema: [],
+    messages: {
+      titlePropDeprecated: 'The `title` prop is deprecated. Please use `ActionList.GroupHeading` instead.',
+    },
+  },
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        const openingElName = getJSXOpeningElementName(node)
+        if (openingElName !== 'ActionList.Group') {
+          return
+        }
+        const title = getJSXOpeningElementAttribute(node, 'title')
+        if (title !== undefined) {
+          console.log('hello', title.name.name, title.value.value)
+          context.report({
+            node,
+            messageId: 'titlePropDeprecated',
+            fix(fixer) {
+              const groupTitle = title.value.value
+              // const sourceCode = context.sourceCode
+              // const start = title.range[0]
+              // const end = sourceCode.getTokenAfter(title).range[1]
+              return [
+                // fixer.removeRange([start, end]),
+                fixer.remove(title),
+                fixer.insertTextAfterRange(
+                  [node.range[1], node.range[1]],
+                  `\n<ActionList.GroupHeading>${groupTitle}</ActionList.GroupHeading>;`,
+                ),
+              ]
+            },
+          })
+        }
+      },
+    }
+  },
+}


### PR DESCRIPTION
Based on [our team discussion about deprecating props that are related to accessibility changes](https://github.com/github/primer/discussions/2911), seems like introducing a complementary eslint rule to enforce the new API (not using the deprecated prop) is a practise worth trying. 

This rule has a generic name but it only handles ActionList.Group title prop (for now). I am not sure if I should make this as generic as its name suggests i.e. adding a deprecated props and suggested fix lists so that we can enhance later or should I rename this to be only specific to ActionList.Group title prop. I am not sure which way would be better. I would love your opinions.

TODO: Ad docs and related config after getting initial feedback.

**Old API**

```jsx
<ActionList>
  <ActionList.Group title="Group title">...</ActionList.Group>
</ActionList>
```

**New API**

```jsx
<ActionList>
  <ActionList.Group>
    <ActionList.GroupHeading>Group title<ActionList.GroupHeading>
  </ActionList.Group>
</ActionList>
```