### PR TITLE
Add mapping of "Box" to "div"

### DIFF
--- a/src/configs/components.js
+++ b/src/configs/components.js
@@ -1,6 +1,6 @@
 const {flattenComponents} = require('../utils/flatten-components')
 
-const components = flattenComponents({
+let components = flattenComponents({
   Button: 'button',
   IconButton: 'button',
   ToggleSwitch: 'button',
@@ -20,4 +20,12 @@ const components = flattenComponents({
   },
 })
 
-module.exports = components
+// We want to avoid setting a jsx-a11y mapping from `Box` to `div` until polymorphic linting is enabled for jsx-a11y.
+// However, polymorphic linting is enabled for the github plugin, so we can safely map `Box` to `div` (while also having it properly interpret the `as` prop)
+let githubMapping = Object.assign({}, components);
+githubMapping['Box'] = 'div'
+
+module.exports = {
+  jsxA11yMapping: components,
+  githubMapping: githubMapping
+}

--- a/src/configs/components.js
+++ b/src/configs/components.js
@@ -1,6 +1,6 @@
 const {flattenComponents} = require('../utils/flatten-components')
 
-let components = flattenComponents({
+const components = flattenComponents({
   Button: 'button',
   IconButton: 'button',
   ToggleSwitch: 'button',
@@ -22,10 +22,10 @@ let components = flattenComponents({
 
 // We want to avoid setting a jsx-a11y mapping from `Box` to `div` until polymorphic linting is enabled for jsx-a11y.
 // However, polymorphic linting is enabled for the github plugin, so we can safely map `Box` to `div` (while also having it properly interpret the `as` prop)
-let githubMapping = Object.assign({}, components);
+const githubMapping = Object.assign({}, components)
 githubMapping['Box'] = 'div'
 
 module.exports = {
   jsxA11yMapping: components,
-  githubMapping: githubMapping
+  githubMapping,
 }

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -1,4 +1,4 @@
-const components = require('./components')
+const {jsxA11yMapping, gihubMapping} = require('./components')
 
 module.exports = {
   parserOptions: {
@@ -19,10 +19,10 @@ module.exports = {
   },
   settings: {
     github: {
-      components,
+      gihubMapping,
     },
     'jsx-a11y': {
-      components,
+      jsxA11yMapping,
     },
   },
 }

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -1,4 +1,4 @@
-const {jsxA11yMapping, gihubMapping} = require('./components')
+const {jsxA11yMapping, githubMapping} = require('./components')
 
 module.exports = {
   parserOptions: {
@@ -19,10 +19,10 @@ module.exports = {
   },
   settings: {
     github: {
-      gihubMapping,
+      components: githubMapping,
     },
     'jsx-a11y': {
-      jsxA11yMapping,
+      components: jsxA11yMapping,
     },
   },
 }


### PR DESCRIPTION
Fixes: https://github.com/primer/eslint-plugin-primer-react/issues/170

This PR adds a mapping of `Box` to `div` to expand a11y linting coverage.

`eslint-plugin-github` has an a11y rule, `a11y-role-supports-aria-props`, which will flag invalid ARIA usage such as:

```.tsx
<Box as="div" aria-label="Something">
```

The plugin can lint the above markup by reading the value of the `as` prop, and interpreting it as a `div`. 

However, because we don't have a mapping defined for `Box` for when `as`  isn't set, the following isn't currently flagged even though it should be flagged as invalid:
```.tsx
<Box aria-label="Something">
```

This PR should will address this issue. I've [tested this in dotcom](https://github.com/github/github/pull/324886).

 I opted to only add the mapping for `eslint-plugin-github` because we have not enabled polymorphic linting for `jsx-a11y` rules yet, and if we define the mapping for `jsx-a11y`, it may raise false positives by always treating `Box` as a `div`.