### PR TITLE
Revert "Add mapping of "Box" to "div""

### DIFF
--- a/src/configs/components.js
+++ b/src/configs/components.js
@@ -20,12 +20,4 @@ const components = flattenComponents({
   },
 })
 
-// We want to avoid setting a jsx-a11y mapping from `Box` to `div` until polymorphic linting is enabled for jsx-a11y.
-// However, polymorphic linting is enabled for the github plugin, so we can safely map `Box` to `div` (while also having it properly interpret the `as` prop)
-const githubMapping = Object.assign({}, components)
-githubMapping['Box'] = 'div'
-
-module.exports = {
-  jsxA11yMapping: components,
-  githubMapping,
-}
+module.exports = components

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -1,4 +1,4 @@
-const {jsxA11yMapping, githubMapping} = require('./components')
+const components = require('./components')
 
 module.exports = {
   parserOptions: {
@@ -19,10 +19,10 @@ module.exports = {
   },
   settings: {
     github: {
-      components: githubMapping,
+      components,
     },
     'jsx-a11y': {
-      components: jsxA11yMapping,
+      components,
     },
   },
 }


### PR DESCRIPTION
I was wondering why a Release tracking PR wasn't being opened. I realized I need to add a changeset. 

Reverts primer/eslint-plugin-primer-react#176 so I can add a changeset when I add it back.

Let me know if there's a better way of approaching this 🤦‍♀️ 