### PR TITLE
Add check changeset workflow

### DIFF
--- a/.github/workflows/check-for-changeset.yml
+++ b/.github/workflows/check-for-changeset.yml
@@ -1,0 +1,25 @@
+name: Check for changeset
+
+on:
+  pull_request:
+    types:
+      # On by default if you specify no types.
+      - 'opened'
+      - 'reopened'
+      - 'synchronize'
+      # For `skip-label` only.
+      - 'labeled'
+      - 'unlabeled'
+
+jobs:
+  check-for-changeset:
+    name: Check for changeset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Check for changeset'
+        uses: brettcannon/check-for-changed-files@v1
+        with:
+          file-pattern: '.changeset/*.md'
+          skip-label: 'skip changeset'
+          failure-message: 'No changeset found. If these changes should not result in a new version, apply the ${skip-label} label to this pull request. If these changes should result in a version bump, please add a changeset https://git.io/J6QvQ'

--- a/.github/workflows/check-for-changeset.yml
+++ b/.github/workflows/check-for-changeset.yml
@@ -23,4 +23,3 @@ jobs:
           file-pattern: '.changeset/*.md'
           skip-label: 'skip changeset'
           failure-message: 'No changeset found. If these changes should not result in a new version, apply the ${skip-label} label to this pull request. If these changes should result in a version bump, please add a changeset https://git.io/J6QvQ'
-          

--- a/.github/workflows/check-for-changeset.yml
+++ b/.github/workflows/check-for-changeset.yml
@@ -23,3 +23,4 @@ jobs:
           file-pattern: '.changeset/*.md'
           skip-label: 'skip changeset'
           failure-message: 'No changeset found. If these changes should not result in a new version, apply the ${skip-label} label to this pull request. If these changes should result in a version bump, please add a changeset https://git.io/J6QvQ'
+          


### PR DESCRIPTION
This PR introduces a workflow to ensure that every PR has a changeset and/or the `skip changeset` label.

Context: I forgot to add a changeset in a PR earlier, and scrambled to add it in a follow-up. Having this check in place will be helpful since it's easy to forget.

I copied the [check changeset workflow](https://github.com/primer/react/blob/c81898c93664d224d7a18722cd1abcdcf2d1a510/.github/workflows/check_for_changeset.yml#L24) over from Primer React!
