### PR TITLE
Introduce a new rule to flag Link in text blocks without `inline`

### DIFF
--- a/.changeset/happy-parents-invite.md
+++ b/.changeset/happy-parents-invite.md
@@ -2,4 +2,4 @@
 "eslint-plugin-primer-react": patch
 ---
 
-New rule to flag links in text block missing the `inline` prop
+New rule to flag `Link` in text block missing the `inline` prop

--- a/.changeset/happy-parents-invite.md
+++ b/.changeset/happy-parents-invite.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+New rule to flag links in text block missing the `inline` prop

--- a/docs/rules/a11y-link-in-text-block.md
+++ b/docs/rules/a11y-link-in-text-block.md
@@ -12,10 +12,10 @@ This rule will not catch all instances of link in text block due to the limitati
 
 The edge cases that the linter skips to avoid false positives will include:
 
-* `<Link sx={{fontWeight:...}}>` or `<Link sx={{fontFamily:...}}>` because these technically may provide sufficient distinguishing styling.
-* `<Link>` where the only adjacent text is a period, since that can't really be considered a text block.
-* `<Link>` where the children is a JSX component, rather than a string literal, because then it might be an icon link rather than a text link.
-* `<Link>` that are nested inside of headings as these have often been breadcrumbs.
+- `<Link sx={{fontWeight:...}}>` or `<Link sx={{fontFamily:...}}>` because these technically may provide sufficient distinguishing styling.
+- `<Link>` where the only adjacent text is a period, since that can't really be considered a text block.
+- `<Link>` where the children is a JSX component, rather than a string literal, because then it might be an icon link rather than a text link.
+- `<Link>` that are nested inside of headings as these have often been breadcrumbs.
 
 👎 Examples of **incorrect** code for this rule
 

--- a/docs/rules/a11y-link-in-text-block.md
+++ b/docs/rules/a11y-link-in-text-block.md
@@ -1,0 +1,88 @@
+## Require `inline` prop on `<Link>` component inside a text block
+
+The `Link` component should have the `inline` prop when it is used inside of a text block.
+
+## Rule Details
+
+This rule enforces setting `inline` on the `<Link>` component when a `<Link>` is detected inside of a text block without distiguishable styling.
+
+This rule will not catch all instances of link in text block due to the limitations of static analysis, so be sure to also have in-browser checks in place such as the [link-in-text-block Axe rule](https://dequeuniversity.com/rules/axe/4.9/link-in-text-block) for additional coverage.
+
+👎 Examples of **incorrect** code for this rule
+
+```jsx
+import {Link} from '@primer/react'
+
+function ExampleComponent() {
+  return (
+    <SomeComponent>
+      <Link>Say hello</Link> or not.
+    </SomeComponent>
+  )
+}
+```
+
+```jsx
+import {Link} from '@primer/react'
+
+function ExampleComponent() {
+  return (
+    <SomeComponent>
+      Say hello or <Link>sign-up</Link>.
+    </SomeComponent>
+  )
+}
+```
+
+👍 Examples of **correct** code for this rule:
+
+```jsx
+function ExampleComponent() {
+  return (
+    <SomeComponent>
+      <Link inline>Say hello</Link> or not.
+    </SomeComponent>
+  )
+}
+```
+
+```jsx
+function ExampleComponent() {
+  return (
+    <SomeComponent>
+      <Link inline={true}>Say hello</Link> or not.
+    </SomeComponent>
+  )
+}
+```
+
+This rule will skip `Link`s containing JSX elements to minimize potential false positives because it is possible the JSX element sufficiently distinguishes the link from surrounding text.
+
+```jsx
+function ExampleComponent() {
+  return (
+    <SomeComponent>
+      <Link><SomeAvatar />@monalisa</Link> commented on your account.
+    </SomeComponent>
+  )
+}
+```
+
+This rule will skip `Link`s nested inside of a `Heading`.
+
+```jsx
+function ExampleComponent() {
+  return (
+    <Heading>
+      <Link>Previous location</Link>
+      / Current location
+    </Heading>
+  )
+}
+```
+
+## Options
+
+- `skipImportCheck` (default: `false`)
+
+By default, the `a11y-explicit-heading` rule will only check for `<Heading>` components imported directly from `@primer/react`. You can disable this behavior by setting `skipImportCheck` to `true`.

--- a/docs/rules/a11y-link-in-text-block.md
+++ b/docs/rules/a11y-link-in-text-block.md
@@ -62,7 +62,11 @@ This rule will skip `Link`s containing JSX elements to minimize potential false 
 function ExampleComponent() {
   return (
     <SomeComponent>
-      <Link><SomeAvatar />@monalisa</Link> commented on your account.
+      <Link>
+        <SomeAvatar />
+        @monalisa
+      </Link>{' '}
+      commented on your account.
     </SomeComponent>
   )
 }
@@ -74,8 +78,7 @@ This rule will skip `Link`s nested inside of a `Heading`.
 function ExampleComponent() {
   return (
     <Heading>
-      <Link>Previous location</Link>
-      / Current location
+      <Link>Previous location</Link>/ Current location
     </Heading>
   )
 }

--- a/docs/rules/a11y-link-in-text-block.md
+++ b/docs/rules/a11y-link-in-text-block.md
@@ -6,7 +6,16 @@ The `Link` component should have the `inline` prop when it is used inside of a t
 
 This rule enforces setting `inline` on the `<Link>` component when a `<Link>` is detected inside of a text block without distiguishable styling.
 
+The lint rule will essentially flag any `<Link>` without the `inline` property (equal to `true`) detected with string nodes on either side.
+
 This rule will not catch all instances of link in text block due to the limitations of static analysis, so be sure to also have in-browser checks in place such as the [link-in-text-block Axe rule](https://dequeuniversity.com/rules/axe/4.9/link-in-text-block) for additional coverage.
+
+The edge cases that the linter skips to avoid false positives will include:
+
+* `<Link sx={{fontWeight:...}}>` or `<Link sx={{fontFamily:...}}>` because these technically may provide sufficient distinguishing styling.
+* `<Link>` where the only adjacent text is a period, since that can't really be considered a text block.
+* `<Link>` where the children is a JSX component, rather than a string literal, because then it might be an icon link rather than a text link.
+* `<Link>` that are nested inside of headings as these have often been breadcrumbs.
 
 👎 Examples of **incorrect** code for this rule
 

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -16,7 +16,6 @@ module.exports = {
     'primer-react/new-color-css-vars': 'error',
     'primer-react/a11y-explicit-heading': 'error',
     'primer-react/no-deprecated-props': 'warn',
-    'primer-react/a11y-link-in-text-block': 'error',
   },
   settings: {
     github: {

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -16,6 +16,7 @@ module.exports = {
     'primer-react/new-color-css-vars': 'error',
     'primer-react/a11y-explicit-heading': 'error',
     'primer-react/no-deprecated-props': 'warn',
+    'primer-react/a11y-link-in-text-block': 'error',
   },
   settings: {
     github: {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ module.exports = {
     'new-color-css-vars': require('./rules/new-color-css-vars'),
     'a11y-explicit-heading': require('./rules/a11y-explicit-heading'),
     'no-deprecated-props': require('./rules/no-deprecated-props'),
+    'a11y-link-in-text-block': require('./rules/a11y-link-in-text-block'),
   },
   configs: {
     recommended: require('./configs/recommended'),

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -32,6 +32,42 @@ ruleTester.run('a11y-link-in-text-block', rule, {
     `import {Link} from '@primer/react';
    <Link>Link level 1</Link>;
 `,
+    `import {Heading, Link} from '@primer/react';
+    <Heading>
+      <Link>Link level 1</Link>
+    </Heading>,
+`,
+    `import {Heading, Link} from '@primer/react';
+    <Heading as="h2">
+    <Link href={somePath}>
+      Breadcrumb
+    </Link>
+    &nbsp;/ Create a thing
+  </Heading>
+`,
+    `import {Link} from '@primer/react';
+    <h2>
+    <Link href={somePath}>
+      Breadcrumb
+    </Link>
+    </h2>
+    &nbsp;/ Create a thing
+  </Heading>
+`,
+    `import {Link} from '@primer/react';
+    <Link href={somePath}>
+      <SomeAvatar></SomeAvatar>
+    </Link>
+    last edited{' '}
+`,
+    `import {Link} from '@primer/react';
+    <span>
+    by{' '}
+    <Link href="something" sx={{fontWeight: 'bold'}}>
+      {listing.owner_login}
+    </Link>
+    </span>
+`,
   ],
   invalid: [
     {

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -13,6 +13,13 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('a11y-link-in-text-block', rule, {
   valid: [
+    `import {Text, Link} from '@primer/react';
+    <Something>
+      <Link href='blah'>
+        blah
+      </Link>
+    </Something>
+    `,
     `import {Link} from '@primer/react';
      <p>bla blah <Link inline={true}>Link level 1</Link></p>;
   `,

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -18,10 +18,10 @@ ruleTester.run('a11y-link-in-text-block', rule, {
   `,
     `import {Link} from '@primer/react';
     <p>bla blah<Link inline>Link level 1</Link></p>;
-`,
+  `,
     `import {Link} from '@primer/react';
     <><span>something</span><Link inline={true}>Link level 1</Link></>;
-`,
+  `,
   ],
   invalid: [
     {
@@ -35,6 +35,13 @@ ruleTester.run('a11y-link-in-text-block', rule, {
       <Box>Something something{' '}
       <Link>Link level 1</Link>
       </Box>
+    `,
+      errors: [{messageId: 'linkInTextBlock'}],
+    },
+    {
+      code: `import {Link} from '@primer/react';
+      <><blah blah blah{' '}
+      <Link>Link level 1</Link></>;
     `,
       errors: [{messageId: 'linkInTextBlock'}],
     },

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -22,6 +22,9 @@ ruleTester.run('a11y-link-in-text-block', rule, {
     `import {Link} from '@primer/react';
     <><span>something</span><Link inline={true}>Link level 1</Link></>;
   `,
+    `import {Link} from '@primer/react';
+   <Link>Link level 1</Link>;
+`,
   ],
   invalid: [
     {

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -32,15 +32,21 @@ ruleTester.run('a11y-link-in-text-block', rule, {
     },
     {
       code: `import {Link} from '@primer/react';
+      <p>bla blah<Link inline={false}>Link level 1</Link></p>
+    `,
+      errors: [{messageId: 'linkInTextBlock'}],
+    },
+    {
+      code: `import {Link} from '@primer/react';
       <Box>Something something{' '}
-      <Link>Link level 1</Link>
+        <Link>Link level 1</Link>
       </Box>
     `,
       errors: [{messageId: 'linkInTextBlock'}],
     },
     {
       code: `import {Link} from '@primer/react';
-      <><blah blah blah{' '}
+      <>blah blah blah{' '}
       <Link>Link level 1</Link></>;
     `,
       errors: [{messageId: 'linkInTextBlock'}],

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -1,0 +1,42 @@
+const rule = require('../a11y-link-in-text-block')
+const {RuleTester} = require('eslint')
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+})
+
+ruleTester.run('a11y-link-in-text-block', rule, {
+  valid: [
+    `import {Link} from '@primer/react';
+     <p>bla blah <Link inline={true}>Link level 1</Link></p>;
+  `,
+    `import {Link} from '@primer/react';
+    <p>bla blah<Link inline>Link level 1</Link></p>;
+`,
+    `import {Link} from '@primer/react';
+    <><span>something</span><Link inline={true}>Link level 1</Link></>;
+`,
+  ],
+  invalid: [
+    {
+      code: `import {Link} from '@primer/react';
+      <p>bla blah<Link>Link level 1</Link></p>
+    `,
+      errors: [{messageId: 'linkInTextBlock'}],
+    },
+    {
+      code: `import {Link} from '@primer/react';
+      <Box>Something something{' '}
+      <Link>Link level 1</Link>
+      </Box>
+    `,
+      errors: [{messageId: 'linkInTextBlock'}],
+    },
+  ],
+})

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -68,7 +68,7 @@ ruleTester.run('a11y-link-in-text-block', rule, {
     `import {Link} from '@primer/react';
     <div>
     <Link href={somePath}>
-      <GitHubAvatar /> <Text sx={{fontWeight: 'bold'}}>{owner}</Text>
+      <GitHubAvatar />{owner}
     </Link>{' '}
     last edited{' '}
     </div>
@@ -89,6 +89,14 @@ ruleTester.run('a11y-link-in-text-block', rule, {
     </Link>
     </span>
 `,
+    `import {Link} from '@primer/react';
+  <span>
+  by
+  <Link href="something" sx={{fontFamily: 'mono'}}>
+    Blah blah
+  </Link>
+  </span>
+  `,
     `import {Link} from '@primer/react';
     <Box>
 

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -108,6 +108,12 @@ ruleTester.run('a11y-link-in-text-block', rule, {
     },
     {
       code: `import {Link} from '@primer/react';
+      <p><Link>Link level 1</Link> something something</p>
+    `,
+      errors: [{messageId: 'linkInTextBlock'}],
+    },
+    {
+      code: `import {Link} from '@primer/react';
       <p>bla blah<Link inline={false}>Link level 1</Link></p>
     `,
       errors: [{messageId: 'linkInTextBlock'}],

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -98,6 +98,15 @@ ruleTester.run('a11y-link-in-text-block', rule, {
     .
     </Box>
 `,
+    `import {Link} from '@primer/react';
+<Heading sx={{fontSize: 1, mb: 3}} as="h3">
+          In addition,{' '}
+          <Link href="https://github.com/pricing" target="_blank">
+            GitHub Team
+          </Link>{' '}
+          includes:
+        </Heading>
+`,
   ],
   invalid: [
     {
@@ -130,6 +139,13 @@ ruleTester.run('a11y-link-in-text-block', rule, {
       code: `import {Link} from '@primer/react';
       <>blah blah blah{' '}
       <Link>Link level 1</Link></>;
+    `,
+      errors: [{messageId: 'linkInTextBlock'}],
+    },
+    {
+      code: `import {Link} from '@primer/react';
+      <>blah blah blah{' '}
+      <Link underline>Link level 1</Link></>;
     `,
       errors: [{messageId: 'linkInTextBlock'}],
     },

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -33,38 +33,41 @@ ruleTester.run('a11y-link-in-text-block', rule, {
    <Link>Link level 1</Link>;
 `,
     `import {Heading, Link} from '@primer/react';
-    <Heading>
-      <Link>Link level 1</Link>
-    </Heading>,
+      <Heading>
+        <Link>Link level 1</Link>
+      </Heading>
 `,
     `import {Heading, Link} from '@primer/react';
     <Heading as="h2">
-    <Link href={somePath}>
-      Breadcrumb
-    </Link>
-    &nbsp;/ Create a thing
-  </Heading>
+      <Link href={somePath}>
+        Breadcrumb
+      </Link>
+      Create a thing
+    </Heading>
 `,
     `import {Link} from '@primer/react';
+    <div>
     <h2>
     <Link href={somePath}>
       Breadcrumb
     </Link>
     </h2>
-    &nbsp;/ Create a thing
-  </Heading>
+    Create a thing
+    </div>
 `,
     `import {Link} from '@primer/react';
+    <div>
     <Link href={somePath}>
       <SomeAvatar></SomeAvatar>
     </Link>
-    last edited{' '}
+    last edited
+    </div>
 `,
     `import {Link} from '@primer/react';
     <span>
-    by{' '}
+    by
     <Link href="something" sx={{fontWeight: 'bold'}}>
-      {listing.owner_login}
+      Blah blah
     </Link>
     </span>
 `,

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -13,15 +13,24 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('a11y-link-in-text-block', rule, {
   valid: [
-    `import {Text, Link} from '@primer/react';
-    <Something>
-      <Link href='blah'>
-        blah
-      </Link>
-    </Something>
-    `,
     `import {Link} from '@primer/react';
-     <p>bla blah <Link inline={true}>Link level 1</Link></p>;
+    <Box>
+  
+    <Link href="something">
+      Blah blah
+    </Link>{' '}
+    . 
+    </Box>
+  `,
+    `import {Text, Link} from '@primer/react';
+  <Something>
+    <Link href='blah'>
+      blah
+    </Link>
+  </Something>
+  `,
+    `import {Link} from '@primer/react';
+    <p>bla blah <Link inline={true}>Link level 1</Link></p>;
   `,
     `import {Link} from '@primer/react';
     <p>bla blah<Link inline>Link level 1</Link></p>;
@@ -71,6 +80,23 @@ ruleTester.run('a11y-link-in-text-block', rule, {
       Blah blah
     </Link>
     </span>
+`,
+    `import {Link} from '@primer/react';
+    <span>
+    by
+    <Link href="something" sx={{fontWeight: 'bold'}}>
+      Blah blah
+    </Link>
+    </span>
+`,
+    `import {Link} from '@primer/react';
+    <Box>
+
+    <Link href="something">
+      Blah blah
+    </Link>{' '}
+    .
+    </Box>
 `,
   ],
   invalid: [

--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -35,6 +35,7 @@ ruleTester.run('a11y-link-in-text-block', rule, {
     `import {Heading, Link} from '@primer/react';
       <Heading>
         <Link>Link level 1</Link>
+        hello
       </Heading>
 `,
     `import {Heading, Link} from '@primer/react';
@@ -58,15 +59,15 @@ ruleTester.run('a11y-link-in-text-block', rule, {
     `import {Link} from '@primer/react';
     <div>
     <Link href={somePath}>
-      <SomeAvatar></SomeAvatar>
-    </Link>
-    last edited
+      <GitHubAvatar /> <Text sx={{fontWeight: 'bold'}}>{owner}</Text>
+    </Link>{' '}
+    last edited{' '}
     </div>
 `,
     `import {Link} from '@primer/react';
     <span>
     by
-    <Link href="something" sx={{fontWeight: 'bold'}}>
+    <Link href="something" sx={{p: 2, fontWeight: 'bold'}}>
       Blah blah
     </Link>
     </span>

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -30,11 +30,14 @@ module.exports = {
           let siblings = node.parent.children
           if (siblings.length > 0) {
             siblings = siblings.filter(childNode => {
-              return !(
-                (childNode.type === 'JSXExpressionContainer' &&
+              return (
+                !(childNode.type === 'JSXText' && /^\s+$/.test(childNode.value)) &&
+                !(
+                  childNode.type === 'JSXExpressionContainer' &&
                   childNode.expression.type === 'Literal' &&
-                  /^\s+$/.test(childNode.expression.raw)) ||
-                (childNode.type === 'Literal' && /^\s+$/.test(childNode.raw))
+                  /^\s+$/.test(childNode.expression.value)
+                ) &&
+                !(childNode.type === 'Literal' && /^\s+$/.test(childNode.value))
               )
             })
             const index = siblings.findIndex(childNode => {

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -28,6 +28,9 @@ module.exports = {
           node.parent.children
         ) {
           let siblings = node.parent.children
+          const parentName = node.parent.openingElement?.name?.name
+          const parentsToSkip = ['Heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+          if (parentsToSkip.includes(parentName)) return
           if (siblings.length > 0) {
             siblings = siblings.filter(childNode => {
               return (
@@ -46,7 +49,24 @@ module.exports = {
             const prevSibling = siblings[index - 1]
             const nextSibling = siblings[index + 1]
             if ((prevSibling && prevSibling.type === 'JSXText') || (nextSibling && nextSibling.type === 'JSXText')) {
+              const sxAttribute = getJSXOpeningElementAttribute(node.openingElement, 'sx')
               const inlineAttribute = getJSXOpeningElementAttribute(node.openingElement, 'inline')
+
+              // Skip is Link child is a JSX element.
+              const jsxElementChildren = node.children.filter(child => {
+                return child.type === 'JSXElement'
+              })
+              if (jsxElementChildren.length > 0) return
+              // Skip if fontWeight is set via the sx prop since that may be sufficient.
+              if (
+                sxAttribute &&
+                sxAttribute?.value?.expression &&
+                sxAttribute.value.expression.type === 'ObjectExpression' &&
+                sxAttribute.value.expression.properties &&
+                sxAttribute.value.expression.properties.length > 0 &&
+                sxAttribute.value.expression.properties[0].key.name === 'fontWeight'
+              )
+                return
               if (inlineAttribute) {
                 if (!inlineAttribute.value) {
                   return

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -15,7 +15,7 @@ module.exports = {
       },
     ],
     messages: {
-      linkInTextBlock: 'Heading must have an explicit heading level applied through the `as` prop.',
+      linkInTextBlock: '<Link> that are used within a text block should have the inline prop.',
     },
   },
   create(context) {
@@ -23,7 +23,15 @@ module.exports = {
       JSXElement(node) {
         const name = getJSXOpeningElementName(node.openingElement)
         if (isPrimerComponent(node.openingElement.name, context.getScope(node)) && name === 'Link') {
-          const siblings = node.parent.children
+          let siblings = node.parent.children
+          siblings = siblings.filter(childNode => {
+            return !(
+              (childNode.type === 'JSXExpressionContainer' &&
+                childNode.expression.type === 'Literal' &&
+                /^\s+$/.test(childNode.expression.raw)) ||
+              (childNode.type === 'Literal' && /^\s+$/.test(childNode.raw))
+            )
+          })
           if (siblings.length > 0) {
             const index = siblings.findIndex(childNode => {
               return childNode.range === node.range

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -15,7 +15,7 @@ module.exports = {
       },
     ],
     messages: {
-      linkInTextBlock: '<Link> that are used within a text block should have the inline prop.',
+      linkInTextBlock: '<Link>s that are used within a text block should have the inline prop.',
     },
   },
   create(context) {
@@ -67,7 +67,7 @@ module.exports = {
               })
               if (jsxElementChildren.length > 0) return
 
-              // Skip if fontWeight is set via the sx prop.
+              // Skip if fontWeight or fontFamily is set via the sx prop since these may technically be considered sufficiently distinguishing styles that don't use color.
               if (
                 sxAttribute &&
                 sxAttribute?.value?.expression &&

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -30,10 +30,7 @@ module.exports = {
             })
             const prevSibling = siblings[index - 1]
             const nextSibling = siblings[index + 1]
-            if (
-              (prevSibling && prevSibling.type === 'JSXText') ||
-              (nextSibling && nextSibling.type === 'JSXText')
-            ) {
+            if ((prevSibling && prevSibling.type === 'JSXText') || (nextSibling && nextSibling.type === 'JSXText')) {
               const inlineAttribute = getJSXOpeningElementAttribute(node.openingElement, 'inline')
               if (inlineAttribute) {
                 if (!inlineAttribute.value) {

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -22,17 +22,21 @@ module.exports = {
     return {
       JSXElement(node) {
         const name = getJSXOpeningElementName(node.openingElement)
-        if (isPrimerComponent(node.openingElement.name, context.getScope(node)) && name === 'Link') {
+        if (
+          isPrimerComponent(node.openingElement.name, context.getScope(node)) &&
+          name === 'Link' &&
+          node.parent.children
+        ) {
           let siblings = node.parent.children
-          siblings = siblings.filter(childNode => {
-            return !(
-              (childNode.type === 'JSXExpressionContainer' &&
-                childNode.expression.type === 'Literal' &&
-                /^\s+$/.test(childNode.expression.raw)) ||
-              (childNode.type === 'Literal' && /^\s+$/.test(childNode.raw))
-            )
-          })
           if (siblings.length > 0) {
+            siblings = siblings.filter(childNode => {
+              return !(
+                (childNode.type === 'JSXExpressionContainer' &&
+                  childNode.expression.type === 'Literal' &&
+                  /^\s+$/.test(childNode.expression.raw)) ||
+                (childNode.type === 'Literal' && /^\s+$/.test(childNode.raw))
+              )
+            })
             const index = siblings.findIndex(childNode => {
               return childNode.range === node.range
             })

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -63,10 +63,13 @@ module.exports = {
                 sxAttribute?.value?.expression &&
                 sxAttribute.value.expression.type === 'ObjectExpression' &&
                 sxAttribute.value.expression.properties &&
-                sxAttribute.value.expression.properties.length > 0 &&
-                sxAttribute.value.expression.properties[0].key.name === 'fontWeight'
-              )
-                return
+                sxAttribute.value.expression.properties.length > 0
+              ) {
+                const fontWeightProperty = sxAttribute.value.expression.properties.filter(property => {
+                  return property.key.name === 'fontWeight'
+                })
+                if (fontWeightProperty.length > 0) return
+              }
               if (inlineAttribute) {
                 if (!inlineAttribute.value) {
                   return

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -1,0 +1,59 @@
+const {isPrimerComponent} = require('../utils/is-primer-component')
+const {getJSXOpeningElementName} = require('../utils/get-jsx-opening-element-name')
+const {getJSXOpeningElementAttribute} = require('../utils/get-jsx-opening-element-attribute')
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    schema: [
+      {
+        properties: {
+          skipImportCheck: {
+            type: 'boolean',
+          },
+        },
+      },
+    ],
+    messages: {
+      linkInTextBlock: 'Heading must have an explicit heading level applied through the `as` prop.',
+    },
+  },
+  create(context) {
+    return {
+      JSXElement(node) {
+        const name = getJSXOpeningElementName(node.openingElement)
+        if (isPrimerComponent(node.openingElement.name, context.getScope(node)) && name === 'Link') {
+          const siblings = node.parent.children
+          if (siblings.length > 0) {
+            const index = siblings.findIndex(childNode => {
+              return childNode.range === node.range
+            })
+            const prevSibling = siblings[index - 1]
+            const nextSibling = siblings[index + 1]
+            if (
+              (prevSibling && prevSibling.type === 'JSXText') ||
+              (nextSibling && nextSibling.type === 'JSXText')
+            ) {
+              const inlineAttribute = getJSXOpeningElementAttribute(node.openingElement, 'inline')
+              if (inlineAttribute) {
+                if (!inlineAttribute.value) {
+                  return
+                } else if (inlineAttribute.value.type === 'JSXExpressionContainer') {
+                  if (inlineAttribute.value.expression.type === 'Literal') {
+                    if (inlineAttribute.value.expression.value === true) {
+                      return
+                    }
+                  }
+                }
+              }
+              context.report({
+                node,
+                messageId: 'linkInTextBlock',
+              })
+            }
+          }
+        }
+      },
+    }
+  },
+}

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -30,6 +30,7 @@ module.exports = {
         ) {
           let siblings = node.parent.children
           const parentName = node.parent.openingElement?.name?.name
+          // Skip if Link is nested inside of a heading.
           const parentsToSkip = ['Heading', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
           if (parentsToSkip.includes(parentName)) return
           if (siblings.length > 0) {
@@ -53,19 +54,20 @@ module.exports = {
             const prevSiblingIsText = prevSibling && prevSibling.type === 'JSXText'
             const nextSiblingIsText = nextSibling && nextSibling.type === 'JSXText'
             if (prevSiblingIsText || nextSiblingIsText) {
-              // If the only text adjacent to the link is a period, then skip it.
+              // Skip if the only text adjacent to the link is a period, then skip it.
               if (!prevSiblingIsText && /^\s*.+\s*$/.test(nextSibling.value)) {
                 return
               }
               const sxAttribute = getJSXOpeningElementAttribute(node.openingElement, 'sx')
               const inlineAttribute = getJSXOpeningElementAttribute(node.openingElement, 'inline')
 
-              // Skip is Link child is a JSX element.
+              // Skip if Link child is a JSX element.
               const jsxElementChildren = node.children.filter(child => {
                 return child.type === 'JSXElement'
               })
               if (jsxElementChildren.length > 0) return
-              // Skip if fontWeight is set via the sx prop since that may be sufficient.
+
+              // Skip if fontWeight is set via the sx prop.
               if (
                 sxAttribute &&
                 sxAttribute?.value?.expression &&

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -48,7 +48,14 @@ module.exports = {
             })
             const prevSibling = siblings[index - 1]
             const nextSibling = siblings[index + 1]
-            if ((prevSibling && prevSibling.type === 'JSXText') || (nextSibling && nextSibling.type === 'JSXText')) {
+
+            const prevSiblingIsText = prevSibling && prevSibling.type === 'JSXText'
+            const nextSiblingIsText = nextSibling && nextSibling.type === 'JSXText'
+            if (prevSiblingIsText || nextSiblingIsText) {
+              // If the only text adjacent to the link is a period, then skip it.
+              if (!prevSiblingIsText && /^\s*.+\s*$/.test(nextSibling.value)) {
+                return
+              }
               const sxAttribute = getJSXOpeningElementAttribute(node.openingElement, 'sx')
               const inlineAttribute = getJSXOpeningElementAttribute(node.openingElement, 'inline')
 

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -19,11 +19,12 @@ module.exports = {
     },
   },
   create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
     return {
       JSXElement(node) {
         const name = getJSXOpeningElementName(node.openingElement)
         if (
-          isPrimerComponent(node.openingElement.name, context.getScope(node)) &&
+          isPrimerComponent(node.openingElement.name, sourceCode.getScope(node)) &&
           name === 'Link' &&
           node.parent.children
         ) {

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -55,7 +55,7 @@ module.exports = {
             const nextSiblingIsText = nextSibling && nextSibling.type === 'JSXText'
             if (prevSiblingIsText || nextSiblingIsText) {
               // Skip if the only text adjacent to the link is a period, then skip it.
-              if (!prevSiblingIsText && /^\s*.+\s*$/.test(nextSibling.value)) {
+              if (!prevSiblingIsText && /^\s*\.+\s*$/.test(nextSibling.value)) {
                 return
               }
               const sxAttribute = getJSXOpeningElementAttribute(node.openingElement, 'sx')

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -75,10 +75,10 @@ module.exports = {
                 sxAttribute.value.expression.properties &&
                 sxAttribute.value.expression.properties.length > 0
               ) {
-                const fontWeightProperty = sxAttribute.value.expression.properties.filter(property => {
-                  return property.key.name === 'fontWeight'
+                const fontStyleProperty = sxAttribute.value.expression.properties.filter(property => {
+                  return property.key.name === 'fontWeight' || property.key.name === 'fontFamily'
                 })
-                if (fontWeightProperty.length > 0) return
+                if (fontStyleProperty.length > 0) return
               }
               if (inlineAttribute) {
                 if (!inlineAttribute.value) {


### PR DESCRIPTION
Relates to: 
* https://github.com/primer/eslint-plugin-primer-react/issues/182
*  https://github.com/github/accessibility/issues/6434

## What

This PR introduces a new accessibility lint rule to ensure that links inside of a text block have the `inline` prop.

## Why

The current recommendation in dotcom is to add `inline` prop on all `Link`s that appear within a text block to ensure that a user’s accessibility link underline setting is respected. 

However, there are currently no automated tools to enforce that developers actually set this prop on their links. As a result, developers continue to add Links to text blocks contributing to [1.4.1: Use of Color accessibility issues](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html).

By having this lint rule in place, we can proactively surface to developers when they should set the `inline` prop.

## Implementation details

The logic essentially treats any `Link` that appears with a string literal on either side of it as a link within a text block. It checks for the presence of `inline` or `inline={true}`. 

For example, the following will be flagged:

```.tsx
<p>
  Learn more about <Link href={...}>GitHub</Link>.
</p>
```

```.tsx
<SomeComponent>
  <Link href={...}>GitHub</Link> is where you share code.
</SomeComponent>
```

In addition, this lint rule aims to minimize false positives and will skip Links even if adjacent text is detected for the following scenarios:

* `<Link sx={{fontWeight:...}}>` or `<Link sx={{fontFamily:...}}>` - these technically may provide sufficient distinguishing styling.
* `<Link>` where the only adjacent text is a period -  these can't really be considered a text block.
* `<Link>` where the children is a JSX component, rather than a string literal -  this is because the JSX component may be an icon link, in which case it may be sufficient to distinguish.
* `<Link>` that are nested inside of headings -  these feel safer to skip...

## Testing / Validation

I've tested this branch against dotcom to make sure there's nothing unexpected! This flagged around 140 `Link` missing inline in dotcom. I've gone ahead and opened fixes for whatever was flagged by this rule [across 8 PRs](https://github.com/github/github/pulls?q=is%3Apr+is%3Aopen+%22%5Breact-link-inline+%22+author%3Akhiga8).

I broke this up into reviewable chunks so that codeowners can make sure to minimize false positives raised by this rule. (Related: https://github.com/github/accessibility/issues/6434)

## Reviewers 📣

1. I am open to any feedback on this logic! Is there anything I'm missing?
2. Is it okay to enable this rule in `recommended.js` or is this only relevant to dotcom?
3. Right now this rule will flag `<Link underline>` even though technically `underline` does provide sufficient styling. I decided to flag `underline` because I noticed it is deprecated so maybe this is an opportunity for consumers to migrate to `inline`. Let me know if you think we shouldn't flag `underline`!