### PR TITLE
Add release_tracking to eslint plugin

### DIFF
--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -3,6 +3,8 @@ name: Release Event Tracking
 
 on:
   pull_request:
+    branches:
+      - 'changeset-release/main'
     types:
       - closed
       - opened

--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -1,0 +1,19 @@
+name: Release Event Tracking
+# Measure a datadog event every time a release occurs
+
+on:
+  pull_request:
+    types:
+      - closed
+      - opened
+      - reopened
+
+  release:
+    types: [published]
+
+jobs:
+  release-tracking:
+    name: Release Tracking
+    uses: primer/.github/.github/workflows/release_tracking.yml@v2.1.0
+    secrets:
+      datadog_api_key: ${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/3181

This adds release tracking to the repo