### PR TITLE
Add a rule that warn against removing `unsafeDisableTooltip` prop from `IconButton`

### DIFF
--- a/.changeset/slow-numbers-invite.md
+++ b/.changeset/slow-numbers-invite.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": minor
+---
+
+Add a rule that warns against removing `unsafeDisableTooltip` prop

--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ ESLint rules for Primer React
 - [a11y-explicit-heading](https://github.com/primer/eslint-plugin-primer-react/blob/main/docs/rules/a11y-explicit-heading.md)
 - [new-css-color-vars](https://github.com/primer/eslint-plugin-primer-react/blob/main/docs/rules/new-css-color-vars.md)
 - [no-deprecated-props](https://github.com/primer/eslint-plugin-primer-react/blob/main/docs/rules/no-deprecated-props.md)
+- [a11y-remove-disable-tooltip](https://github.com/primer/eslint-plugin-primer-react/blob/main/docs/rules/a11y-remove-disable-tooltip.md)

--- a/docs/rules/a11y-remove-disable-tooltip.md
+++ b/docs/rules/a11y-remove-disable-tooltip.md
@@ -11,6 +11,8 @@ const App = () => (
   <IconButton icon={SearchIcon} aria-label="Search" unsafeDisableTooltip />
   // OR
   <IconButton icon={SearchIcon} aria-label="Search" unsafeDisableTooltip={true} />
+  // OR
+  <IconButton icon={SearchIcon} aria-label="Search" unsafeDisableTooltip={false} /> // This is incorrect because it should be removed
 )
 ```
 

--- a/docs/rules/a11y-remove-disable-tooltip.md
+++ b/docs/rules/a11y-remove-disable-tooltip.md
@@ -1,0 +1,23 @@
+## Rule Details
+
+This rule enforces to remove the `unsafeDisableTooltip` from `IconButton` component so that they have a tooltip by default. `unsafeDisableTooltip` prop is created for an incremental migration and should be removed once all icon buttons have a tooltip.
+
+👎 Examples of **incorrect** code for this rule:
+
+```jsx
+import {IconButton} from '@primer/react'
+
+const App = () => (
+  <IconButton icon={SearchIcon} aria-label="Search" unsafeDisableTooltip />
+  // OR
+  <IconButton icon={SearchIcon} aria-label="Search" unsafeDisableTooltip={true} />
+)
+```
+
+👍 Examples of **correct** code for this rule:
+
+```jsx
+import {IconButton} from '@primer/react'
+
+const App = () => <IconButton icon={SearchIcon} aria-label="Search" />
+```

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -16,6 +16,7 @@ module.exports = {
     'primer-react/new-color-css-vars': 'error',
     'primer-react/a11y-explicit-heading': 'error',
     'primer-react/no-deprecated-props': 'warn',
+    'primer-react/a11y-remove-disable-tooltip': 'error',
   },
   settings: {
     github: {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ module.exports = {
     'new-color-css-vars': require('./rules/new-color-css-vars'),
     'a11y-explicit-heading': require('./rules/a11y-explicit-heading'),
     'no-deprecated-props': require('./rules/no-deprecated-props'),
+    'a11y-remove-disable-tooltip': require('./rules/a11y-remove-disable-tooltip'),
   },
   configs: {
     recommended: require('./configs/recommended'),

--- a/src/rules/__tests__/a11y-remove-disable-tooltip.test.js
+++ b/src/rules/__tests__/a11y-remove-disable-tooltip.test.js
@@ -37,5 +37,14 @@ ruleTester.run('a11y-remove-disable-tooltip', rule, {
         },
       ],
     },
+    {
+      code: `<IconButton icon={SearchIcon} aria-label="Search" unsafeDisableTooltip={false} />`,
+      output: `<IconButton icon={SearchIcon} aria-label="Search" />`,
+      errors: [
+        {
+          messageId: 'removeDisableTooltipProp',
+        },
+      ],
+    },
   ],
 })

--- a/src/rules/__tests__/a11y-remove-disable-tooltip.test.js
+++ b/src/rules/__tests__/a11y-remove-disable-tooltip.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const {RuleTester} = require('eslint')
+const rule = require('../a11y-remove-disable-tooltip')
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+})
+
+ruleTester.run('a11y-remove-disable-tooltip', rule, {
+  valid: [
+    `import {IconButton} from '@primer/react';
+    <IconButton icon={SearchIcon} aria-label="Search" />`,
+  ],
+  invalid: [
+    {
+      code: `<IconButton icon={SearchIcon} aria-label="Search" unsafeDisableTooltip />`,
+      output: `<IconButton icon={SearchIcon} aria-label="Search" />`,
+      errors: [
+        {
+          messageId: 'removeDisableTooltipProp',
+        },
+      ],
+    },
+    {
+      code: `<IconButton icon={SearchIcon} aria-label="Search" unsafeDisableTooltip={true} />`,
+      output: `<IconButton icon={SearchIcon} aria-label="Search" />`,
+      errors: [
+        {
+          messageId: 'removeDisableTooltipProp',
+        },
+      ],
+    },
+  ],
+})

--- a/src/rules/a11y-remove-disable-tooltip.js
+++ b/src/rules/a11y-remove-disable-tooltip.js
@@ -17,7 +17,7 @@ module.exports = {
     schema: [],
     messages: {
       removeDisableTooltipProp:
-        'Please remove `unsafeDisableTooltip` prop from `IconButton` component to enable the tooltip and help making icon button more accessible.',
+        'Please remove `unsafeDisableTooltip` prop from `IconButton` component to enable the tooltip and help make icon button more accessible.',
     },
   },
   create(context) {

--- a/src/rules/a11y-remove-disable-tooltip.js
+++ b/src/rules/a11y-remove-disable-tooltip.js
@@ -1,0 +1,47 @@
+'use strict'
+const {getJSXOpeningElementAttribute} = require('../utils/get-jsx-opening-element-attribute')
+const {getJSXOpeningElementName} = require('../utils/get-jsx-opening-element-name')
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'error',
+    docs: {
+      description:
+        'Icon buttons should have tooltip by default. Please remove `unsafeDisableTooltip` prop from `IconButton` component to enable the tooltip and help making icon button more accessible.',
+      recommended: true,
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      removeDisableTooltipProp:
+        'Please remove `unsafeDisableTooltip` prop from `IconButton` component to enable the tooltip and help making icon button more accessible.',
+    },
+  },
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        const openingElName = getJSXOpeningElementName(node)
+        if (openingElName !== 'IconButton') {
+          return
+        }
+        const unsafeDisableTooltip = getJSXOpeningElementAttribute(node, 'unsafeDisableTooltip')
+        if (unsafeDisableTooltip !== undefined) {
+          context.report({
+            node,
+            messageId: 'removeDisableTooltipProp',
+            fix(fixer) {
+              const start = unsafeDisableTooltip.range[0]
+              const end = unsafeDisableTooltip.range[1]
+              return [
+                fixer.removeRange([start - 1, end]), // remove the space before unsafeDisableTooltip as well
+              ]
+            },
+          })
+        }
+      },
+    }
+  },
+}


### PR DESCRIPTION
Based on the icon button roll out plan ([reference - internal only](https://github.com/github/primer/discussions/3027#discussioncomment-9503729)), I pushed a rule to motivate adoption of tooltips in icon buttons. 

The rule has an auto fix which simply removes the `unsafeDisableTooltip` prop. The plan is to include this rule to score cards (still in the process of clarifying this with @TylerJDev and @khiga8 ) and enable it at dotcom along with disabling the rule for each instances of icon buttons. 


Current
```jsx
<IconButton aria-label="Search" icon={SearchIcon} onClick={onClick} />
```

Aim
```jsx
// eslint-disable-next-line a11y-remove-disable-tooltip
<IconButton aria-label="Search" icon={SearchIcon} onClick={onClick} unsafeDisableTooltip={true} />
```

### Question

One of the steps of the roll out is to provide resources for product teams to give them the adoption plan that includes testing the icon button after removing `unsafeDisableTooltip` prop. I wonder if we can achieve this via this rule? Maybe including this on the docs and providing a url of the rule? I am open to any ideas for sharing the path with the teams.