### PR TITLE
Cleanup: Eliminate deprecation warning of context.getScope

### DIFF
--- a/src/rules/a11y-explicit-heading.js
+++ b/src/rules/a11y-explicit-heading.js
@@ -46,12 +46,13 @@ module.exports = {
     },
   },
   create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
     return {
       JSXOpeningElement(jsxNode) {
         const skipImportCheck = context.options[0] ? context.options[0].skipImportCheck : false
 
         if (
-          (skipImportCheck || isPrimerComponent(jsxNode.name, context.getScope(jsxNode))) &&
+          (skipImportCheck || isPrimerComponent(jsxNode.name, sourceCode.getScope(jsxNode))) &&
           isHeadingComponent(jsxNode)
         ) {
           const error = isInvalid(jsxNode)

--- a/src/rules/a11y-tooltip-interactive-trigger.js
+++ b/src/rules/a11y-tooltip-interactive-trigger.js
@@ -152,13 +152,14 @@ module.exports = {
     },
   },
   create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
     return {
       JSXElement(jsxNode) {
         // If `skipImportCheck` is true, this rule will check for non-interactive element in any components (not just ones that are imported from `@primer/react`).
         const skipImportCheck = context.options[0] ? context.options[0].skipImportCheck : false
         const name = getJSXOpeningElementName(jsxNode.openingElement)
         if (
-          (skipImportCheck || isPrimerComponent(jsxNode.openingElement.name, context.getScope(jsxNode))) &&
+          (skipImportCheck || isPrimerComponent(jsxNode.openingElement.name, sourceCode.getScope(jsxNode))) &&
           name === 'Tooltip' &&
           jsxNode.children
         ) {

--- a/src/rules/direct-slot-children.js
+++ b/src/rules/direct-slot-children.js
@@ -45,6 +45,7 @@ module.exports = {
   },
   create(context) {
     const stack = []
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
     return {
       JSXOpeningElement(jsxNode) {
         const name = getJSXOpeningElementName(jsxNode)
@@ -56,7 +57,7 @@ module.exports = {
         // If component is a Primer component and a slot child,
         // check if it's a direct child of the slot parent
         if (
-          (skipImportCheck || isPrimerComponent(jsxNode.name, context.getScope(jsxNode))) &&
+          (skipImportCheck || isPrimerComponent(jsxNode.name, sourceCode.getScope(jsxNode))) &&
           slotChildToParentMap[name]
         ) {
           const expectedParentNames = slotChildToParentMap[name]

--- a/src/rules/no-system-props.js
+++ b/src/rules/no-system-props.js
@@ -78,6 +78,8 @@ module.exports = {
       ...(includeUtilityComponents ? [] : utilityComponents),
     ])
 
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
+
     return {
       JSXOpeningElement(jsxNode) {
         if (skipImportCheck) {
@@ -86,7 +88,7 @@ module.exports = {
           if (isHTMLElement(jsxNode)) return
         } else {
           // skip if component is not imported from primer/react
-          if (!isPrimerComponent(jsxNode.name, context.getScope(jsxNode))) return
+          if (!isPrimerComponent(jsxNode.name, sourceCode.getScope(jsxNode))) return
         }
 
         const componentName = getJSXOpeningElementName(jsxNode)


### PR DESCRIPTION
I keep getting deprecation notices when I run the tests. 

This PR gets rid of the warnings by migrates away from the deprecated syntax, `context.getScope()`. I followed the [guidance in ESLint for context.getScope](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context.getscope()).  ✨ 

```
 PASS  src/rules/__tests__/no-deprecated-entrypoints.test.js
(node:11722) DeprecationWarning: "a11y-explicit-heading" rule is using `context.getScope()`, which is deprecated and will be removed in ESLint v9. Please use `sourceCode.getScope()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  src/rules/__tests__/a11y-explicit-heading.test.js
 PASS  src/rules/__tests__/no-deprecated-props.test.js
(node:11721) DeprecationWarning: "direct-slot-children" rule is using `context.getScope()`, which is deprecated and will be removed in ESLint v9. Please use `sourceCode.getScope()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  src/rules/__tests__/direct-slot-children.test.js
(node:11719) DeprecationWarning: "no-system-props" rule is using `context.getScope()`, which is deprecated and will be removed in ESLint v9. Please use `sourceCode.getScope()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  src/rules/__tests__/no-system-props.test.js
 PASS  src/rules/__tests__/new-color-css-vars.test.js
(node:11717) DeprecationWarning: "non-interactive-tooltip-trigger" rule is using `context.getScope()`, which is deprecated and will be removed in ESLint v9. Please use `sourceCode.getScope()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```