### PR TITLE
bump eslint-plugin-github to v5.0.1

### DIFF
--- a/.changeset/hip-coats-fetch.md
+++ b/.changeset/hip-coats-fetch.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": minor
+---
+
+* bump eslint-plugin-github to v5.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@styled-system/props": "^5.1.5",
-        "eslint-plugin-github": "^5.0.0",
+        "eslint-plugin-github": "^5.0.1",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-traverse": "^1.0.0",
         "lodash": "^4.17.21",
@@ -3704,9 +3704,9 @@
       }
     },
     "node_modules/eslint-plugin-github": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.0.tgz",
-      "integrity": "sha512-11xKeGGdY42z1e6ZcsNXasjY9Gei4u2Em5Sl/iWPqVzrqYfb/93vvikhp5zS+OBZp+yoH1IPGpevIKxBIbMfEw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.1.tgz",
+      "integrity": "sha512-qbXG3wL5Uh2JB92EKeX2hPtO9c/t75qVxQjVLYuTFfhHifLZzv9CBvLCvoaBhLrAC/xTMVht7DK/NofYK8X4Dg==",
       "dependencies": {
         "@github/browserslist-config": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
@@ -11434,9 +11434,9 @@
       }
     },
     "eslint-plugin-github": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.0.tgz",
-      "integrity": "sha512-11xKeGGdY42z1e6ZcsNXasjY9Gei4u2Em5Sl/iWPqVzrqYfb/93vvikhp5zS+OBZp+yoH1IPGpevIKxBIbMfEw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.1.tgz",
+      "integrity": "sha512-qbXG3wL5Uh2JB92EKeX2hPtO9c/t75qVxQjVLYuTFfhHifLZzv9CBvLCvoaBhLrAC/xTMVht7DK/NofYK8X4Dg==",
       "requires": {
         "@github/browserslist-config": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "eslint-plugin-primer-react",
-  "version": "4.1.2",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-primer-react",
-      "version": "4.1.2",
+      "version": "5.1.0",
       "license": "MIT",
       "dependencies": {
         "@styled-system/props": "^5.1.5",
-        "eslint-plugin-github": "^4.10.1",
+        "eslint-plugin-github": "^5.0.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-traverse": "^1.0.0",
         "lodash": "^4.17.21",
@@ -3704,9 +3704,9 @@
       }
     },
     "node_modules/eslint-plugin-github": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.10.2.tgz",
-      "integrity": "sha512-F1F5aAFgi1Y5hYoTFzGQACBkw5W1hu2Fu5FSTrMlXqrojJnKl1S2pWO/rprlowRQpt+hzHhqSpsfnodJEVd5QA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.0.tgz",
+      "integrity": "sha512-11xKeGGdY42z1e6ZcsNXasjY9Gei4u2Em5Sl/iWPqVzrqYfb/93vvikhp5zS+OBZp+yoH1IPGpevIKxBIbMfEw==",
       "dependencies": {
         "@github/browserslist-config": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
@@ -11434,9 +11434,9 @@
       }
     },
     "eslint-plugin-github": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.10.2.tgz",
-      "integrity": "sha512-F1F5aAFgi1Y5hYoTFzGQACBkw5W1hu2Fu5FSTrMlXqrojJnKl1S2pWO/rprlowRQpt+hzHhqSpsfnodJEVd5QA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.0.tgz",
+      "integrity": "sha512-11xKeGGdY42z1e6ZcsNXasjY9Gei4u2Em5Sl/iWPqVzrqYfb/93vvikhp5zS+OBZp+yoH1IPGpevIKxBIbMfEw==",
       "requires": {
         "@github/browserslist-config": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@styled-system/props": "^5.1.5",
-    "eslint-plugin-github": "^5.0.0",
+    "eslint-plugin-github": "^5.0.1",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-traverse": "^1.0.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@styled-system/props": "^5.1.5",
-    "eslint-plugin-github": "^4.10.1",
+    "eslint-plugin-github": "^5.0.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-traverse": "^1.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Bumps the dependency, `eslint-plugin-github`, to the latest major version which includes:

* [release notes v5.0.0](https://github.com/github/eslint-plugin-github/releases): drops support for node 14 and node 16 in favor of node 18.
* [release notes v5.0.1](https://github.com/github/eslint-plugin-github/releases/tag/v5.0.1) : changes to the recommended config for `no-redundant-roles`. 