### PR TITLE
Update link lint rule to skip Link with className

### DIFF
--- a/src/rules/__tests__/a11y-link-in-text-block.test.js
+++ b/src/rules/__tests__/a11y-link-in-text-block.test.js
@@ -115,6 +115,16 @@ ruleTester.run('a11y-link-in-text-block', rule, {
           includes:
         </Heading>
 `,
+    `import {Link} from '@primer/react';
+      <p>bla blah
+      <Link className={styles.someClass}>Link text</Link>
+      </p>
+    `,
+    `import {Link} from '@primer/react';
+    <p>bla blah
+    <Link className='some-class'>Link text</Link>
+    </p>
+  `,
   ],
   invalid: [
     {

--- a/src/rules/a11y-link-in-text-block.js
+++ b/src/rules/a11y-link-in-text-block.js
@@ -28,6 +28,10 @@ module.exports = {
           name === 'Link' &&
           node.parent.children
         ) {
+          // Skip if Link has className because we cannot deduce what styles are applied.
+          const classNameAttribute = getJSXOpeningElementAttribute(node.openingElement, 'className')
+          if (classNameAttribute) return
+
           let siblings = node.parent.children
           const parentName = node.parent.openingElement?.name?.name
           // Skip if Link is nested inside of a heading.


### PR DESCRIPTION
Fixes: https://github.com/primer/eslint-plugin-primer-react/issues/192

This PR modifies the `a11y-link-in-text-block` rule to avoid flagging `Link` in text block if it also has the `className` on it.

The `a11y-link-in-text-block` is aimed at flagging `Link` that do not have distinguishing styles on it, and encourages the use of the `inline` prop to underline the link.

Sometimes, the `Link` has a `className` attribute on it to style it differently with CSS classes. In such cases, the rule should skip the `Link` because it's possible the CSS class provides sufficient styling, though it cannot be 100% confident given limits of static analysis. This errs on the side of caution to avoid false positive flags.

