### PR TITLE
Update `isPrimerComponent` helper to only match `@primer/react` exactly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-primer-react",
-  "version": "5.4.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-primer-react",
-      "version": "5.4.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
         "@styled-system/props": "^5.1.5",

--- a/src/rules/__tests__/no-unnecessary-components.test.js
+++ b/src/rules/__tests__/no-unnecessary-components.test.js
@@ -7,7 +7,7 @@ const rule = require('../no-unnecessary-components')
 const {components} = require('../no-unnecessary-components')
 
 const prcImport = 'import React from "react"; import {Box, Text} from "@primer/react";'
-const brandImport = 'import React from "react"; import {Box, Text} from "@primer/brand";'
+const brandImport = 'import React from "react"; import {Box, Text} from "@primer/react-brand";'
 
 /** @param {string} content */
 const jsx = content => `export const Component = () => <>${content}</>`

--- a/src/utils/is-primer-component.js
+++ b/src/utils/is-primer-component.js
@@ -15,6 +15,6 @@ function isPrimerComponent(name, scope) {
       return false
   }
 
-  return isImportedFrom(/^@primer\/react/, identifier, scope)
+  return isImportedFrom(/^@primer\/react$/, identifier, scope)
 }
 exports.isPrimerComponent = isPrimerComponent


### PR DESCRIPTION
The `isPrimerComponent` helper uses the regex `/^@primer\/react/` to see if the import path is from `@primer/react`. At first glance this appears fine, but it's critically missing an 'end of string' token, meaning that it will match any path _starting with_ `@primer/react`. This includes `@primer/react-brand` - one of the exact paths we are trying _not_ to match in the `no-unnecessary-components` rule.

This PR updates the regex to `/^@primer\/react$/`.

The rule does have a unit test for this case, but the unit test was incorrectly configured to import from `@primer/brand` instead of `@primer/react-brand`.