### PR TITLE
feat: add no-wildcard-imports rule

### DIFF
--- a/.changeset/breezy-insects-scream.md
+++ b/.changeset/breezy-insects-scream.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-primer-react': minor
+---
+
+Add eslint rule for discouraging use of wildcard imports from @primer/react

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+**/dist/**
+**/node_modules/**

--- a/docs/rules/no-wildcard-imports.md
+++ b/docs/rules/no-wildcard-imports.md
@@ -1,0 +1,25 @@
+# No Wildcard Imports
+
+## Rule Details
+
+This rule enforces that no wildcard imports are used from `@primer/react`.
+
+👎 Examples of **incorrect** code for this rule
+
+```jsx
+import {Dialog} from '@primer/react/lib-esm/Dialog/Dialog'
+
+function ExampleComponent() {
+  return <Dialog>{/* ... */}</Dialog>
+}
+```
+
+👍 Examples of **correct** code for this rule:
+
+```jsx
+import {Dialog} from '@primer/react/experimental'
+
+function ExampleComponent() {
+  return <Dialog>{/* ... */}</Dialog>
+}
+```

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ module.exports = {
     'a11y-remove-disable-tooltip': require('./rules/a11y-remove-disable-tooltip'),
     'a11y-use-next-tooltip': require('./rules/a11y-use-next-tooltip'),
     'use-deprecated-from-deprecated': require('./rules/use-deprecated-from-deprecated'),
+    'no-wildcard-imports': require('./rules/no-wildcard-imports'),
     'no-unnecessary-components': require('./rules/no-unnecessary-components'),
     'prefer-action-list-item-onselect': require('./rules/prefer-action-list-item-onselect'),
   },

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const {RuleTester} = require('eslint')
+const rule = require('../no-wildcard-imports')
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+})
+
+ruleTester.run('no-wildcard-imports', rule, {
+  valid: [`import {Button} from '@primer/react'`],
+  invalid: [
+    // Test unknown path from wildcard import
+    {
+      code: `import type {UnknownImport} from '@primer/react/lib-esm/unknown-path'`,
+      errors: [
+        {
+          message: 'Wildcard imports from @primer/react are not allowed. Import from an entrypoint instead',
+        },
+      ],
+    },
+
+    // Test type import
+    {
+      code: `import type {SxProp} from '@primer/react/lib-esm/sx'`,
+      output: `import type {SxProp} from '@primer/react'`,
+      errors: [
+        {
+          message: 'Wildcard imports from @primer/react/lib-esm/sx are not allowed. Import from an entrypoint instead',
+        },
+      ],
+    },
+
+    // Test multiple type imports
+    {
+      code: `import type {BetterSystemStyleObject, SxProp, BetterCssProperties} from '@primer/react/lib-esm/sx'`,
+      output: `import type {BetterSystemStyleObject, SxProp, BetterCssProperties} from '@primer/react'`,
+      errors: [
+        {
+          message: 'Wildcard imports from @primer/react/lib-esm/sx are not allowed. Import from an entrypoint instead',
+        },
+      ],
+    },
+
+    // Test import alias
+    {
+      code: `import type {SxProp as RenamedSxProp} from '@primer/react/lib-esm/sx'`,
+      output: `import type {SxProp as RenamedSxProp} from '@primer/react'`,
+      errors: [
+        {
+          message: 'Wildcard imports from @primer/react/lib-esm/sx are not allowed. Import from an entrypoint instead',
+        },
+      ],
+    },
+
+    // Test default import
+    {
+      code: `import useIsomorphicLayoutEffect from '@primer/react/lib-esm/useIsomorphicLayoutEffect'`,
+      output: `import {useIsomorphicLayoutEffect} from '@primer/react'`,
+      errors: [
+        {
+          message:
+            'Wildcard imports from @primer/react/lib-esm/useIsomorphicLayoutEffect are not allowed. Import from an entrypoint instead',
+        },
+      ],
+    },
+
+    // Test multiple wildcard imports into single entrypoint
+    {
+      code: `import useResizeObserver from '@primer/react/lib-esm/hooks/useResizeObserver'
+import useIsomorphicLayoutEffect from '@primer/react/lib-esm/useIsomorphicLayoutEffect'`,
+      output: `import {useResizeObserver} from '@primer/react'
+import {useIsomorphicLayoutEffect} from '@primer/react'`,
+      errors: [
+        {
+          message:
+            'Wildcard imports from @primer/react/lib-esm/hooks/useResizeObserver are not allowed. Import from an entrypoint instead',
+        },
+        {
+          message:
+            'Wildcard imports from @primer/react/lib-esm/useIsomorphicLayoutEffect are not allowed. Import from an entrypoint instead',
+        },
+      ],
+    },
+  ],
+})

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -22,7 +22,7 @@ ruleTester.run('no-wildcard-imports', rule, {
       code: `import type {UnknownImport} from '@primer/react/lib-esm/unknown-path'`,
       errors: [
         {
-          message: 'Wildcard imports from @primer/react are not allowed. Import from an entrypoint instead',
+          messageId: 'unknownWildcardImport',
         },
       ],
     },
@@ -33,7 +33,10 @@ ruleTester.run('no-wildcard-imports', rule, {
       output: `import type {SxProp} from '@primer/react'`,
       errors: [
         {
-          message: 'Wildcard imports from @primer/react/lib-esm/sx are not allowed. Import from an entrypoint instead',
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/sx',
+          },
         },
       ],
     },
@@ -44,7 +47,10 @@ ruleTester.run('no-wildcard-imports', rule, {
       output: `import type {BetterSystemStyleObject, SxProp, BetterCssProperties} from '@primer/react'`,
       errors: [
         {
-          message: 'Wildcard imports from @primer/react/lib-esm/sx are not allowed. Import from an entrypoint instead',
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/sx',
+          },
         },
       ],
     },
@@ -55,7 +61,10 @@ ruleTester.run('no-wildcard-imports', rule, {
       output: `import type {SxProp as RenamedSxProp} from '@primer/react'`,
       errors: [
         {
-          message: 'Wildcard imports from @primer/react/lib-esm/sx are not allowed. Import from an entrypoint instead',
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/sx',
+          },
         },
       ],
     },
@@ -66,8 +75,10 @@ ruleTester.run('no-wildcard-imports', rule, {
       output: `import {useIsomorphicLayoutEffect} from '@primer/react'`,
       errors: [
         {
-          message:
-            'Wildcard imports from @primer/react/lib-esm/useIsomorphicLayoutEffect are not allowed. Import from an entrypoint instead',
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/useIsomorphicLayoutEffect',
+          },
         },
       ],
     },
@@ -75,17 +86,276 @@ ruleTester.run('no-wildcard-imports', rule, {
     // Test multiple wildcard imports into single entrypoint
     {
       code: `import useResizeObserver from '@primer/react/lib-esm/hooks/useResizeObserver'
-import useIsomorphicLayoutEffect from '@primer/react/lib-esm/useIsomorphicLayoutEffect'`,
+    import useIsomorphicLayoutEffect from '@primer/react/lib-esm/useIsomorphicLayoutEffect'`,
       output: `import {useResizeObserver} from '@primer/react'
-import {useIsomorphicLayoutEffect} from '@primer/react'`,
+    import {useIsomorphicLayoutEffect} from '@primer/react'`,
       errors: [
         {
-          message:
-            'Wildcard imports from @primer/react/lib-esm/hooks/useResizeObserver are not allowed. Import from an entrypoint instead',
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/hooks/useResizeObserver',
+          },
         },
         {
-          message:
-            'Wildcard imports from @primer/react/lib-esm/useIsomorphicLayoutEffect are not allowed. Import from an entrypoint instead',
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/useIsomorphicLayoutEffect',
+          },
+        },
+      ],
+    },
+
+    // Test migrations
+
+    // Components --------------------------------------------------------------
+    {
+      code: `import {ButtonBase} from '@primer/react/lib-esm/Button/ButtonBase';
+import type {ButtonBaseProps} from '@primer/react/lib-esm/Button/ButtonBase'`,
+      output: `import {ButtonBase} from '@primer/react'
+import type {ButtonBaseProps} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/Button/ButtonBase',
+          },
+        },
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/Button/ButtonBase',
+          },
+        },
+      ],
+    },
+    {
+      code: `import type {ButtonBaseProps} from '@primer/react/lib-esm/Button/types'`,
+      output: `import type {ButtonBaseProps} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/Button/types',
+          },
+        },
+      ],
+    },
+    {
+      code: `import {Dialog} from '@primer/react/lib-esm/Dialog/Dialog'`,
+      output: `import {Dialog} from '@primer/react/experimental'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/Dialog/Dialog',
+          },
+        },
+      ],
+    },
+    {
+      code: `import {SelectPanel} from '@primer/react/lib-esm/SelectPanel/SelectPanel'`,
+      output: `import {SelectPanel} from '@primer/react/experimental'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/SelectPanel/SelectPanel',
+          },
+        },
+      ],
+    },
+    {
+      code: `import type {SelectPanelProps} from '@primer/react/lib-esm/SelectPanel/SelectPanel'`,
+      output: `import type {SelectPanelProps} from '@primer/react/experimental'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/SelectPanel/SelectPanel',
+          },
+        },
+      ],
+    },
+    {
+      code: `import type {LabelColorOptions} from '@primer/react/lib-esm/Label/Label'`,
+      output: `import type {LabelColorOptions} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/Label/Label',
+          },
+        },
+      ],
+    },
+    {
+      code: `import VisuallyHidden from '@primer/react/lib-esm/_VisuallyHidden'`,
+      output: `import {VisuallyHidden} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/_VisuallyHidden',
+          },
+        },
+      ],
+    },
+    {
+      code: `import type {IssueLabelTokenProps} from '@primer/react/lib-esm/Token/IssueLabelToken'`,
+      output: `import type {IssueLabelTokenProps} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/Token/IssueLabelToken',
+          },
+        },
+      ],
+    },
+    {
+      code: `import type {TokenSizeKeys} from '@primer/react/lib-esm/Token/TokenBase'`,
+      output: `import type {TokenSizeKeys} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/Token/TokenBase',
+          },
+        },
+      ],
+    },
+    {
+      code: `import type {ItemProps} from '@primer/react/lib-esm/deprecated/ActionList'`,
+      output: `import type {ActionListItemProps} from '@primer/react/deprecated'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/deprecated/ActionList',
+          },
+        },
+      ],
+    },
+    {
+      code: `import type {GroupedListProps} from '@primer/react/lib-esm/deprecated/ActionList/List'`,
+      output: `import type {ActionListGroupedListProps} from '@primer/react/deprecated'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/deprecated/ActionList/List',
+          },
+        },
+      ],
+    },
+    {
+      code: `import {ItemInput} from '@primer/react/lib-esm/deprecated/ActionList/List'`,
+      output: `import {ActionListItemInput} from '@primer/react/deprecated'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/deprecated/ActionList/List',
+          },
+        },
+      ],
+    },
+    {
+      code: `import type {ItemProps} from '@primer/react/lib-esm/deprecated/ActionList/Item'`,
+      output: `import type {ActionListItemProps} from '@primer/react/deprecated'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/deprecated/ActionList/Item',
+          },
+        },
+      ],
+    },
+
+    // Hooks -------------------------------------------------------------------
+
+    // @primer/react/lib-esm/useIsomorphicLayoutEffect
+    {
+      code: `import useIsomorphicLayoutEffect from '@primer/react/lib-esm/useIsomorphicLayoutEffect'`,
+      output: `import {useIsomorphicLayoutEffect} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/useIsomorphicLayoutEffect',
+          },
+        },
+      ],
+    },
+
+    // @primer/react/lib-esm/hooks/useResizeObserver
+    {
+      code: `import useResizeObserver from '@primer/react/lib-esm/hooks/useResizeObserver'`,
+      output: `import {useResizeObserver} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/hooks/useResizeObserver',
+          },
+        },
+      ],
+    },
+
+    // @primer/react/lib-esm/hooks/useProvidedRefOrCreate
+    {
+      code: `import useProvidedRefOrCreate from '@primer/react/lib-esm/hooks/useProvidedRefOrCreate'`,
+      output: `import {useProvidedRefOrCreate} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/hooks/useProvidedRefOrCreate',
+          },
+        },
+      ],
+    },
+
+    // @primer/react/lib-esm/hooks/useResponsiveValue
+    {
+      code: `import useResponsiveValue from '@primer/react/lib-esm/hooks/useResponsiveValue'`,
+      output: `import {useResponsiveValue} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/hooks/useResponsiveValue',
+          },
+        },
+      ],
+    },
+
+    // Utilities ---------------------------------------------------------------
+
+    // @primer/react/lib-esm/sx
+    {
+      code: `import type {BetterSystemStyleObject, SxProp, BetterCssProperties} from '@primer/react/lib-esm/sx'`,
+      output: `import type {BetterSystemStyleObject, SxProp, BetterCssProperties} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/sx',
+          },
+        },
+      ],
+    },
+    // @primer/react/lib-esm/FeatureFlags/DefaultFeatureFlags
+    {
+      code: `import {DefaultFeatureFlags} from '@primer/react/lib-esm/FeatureFlags/DefaultFeatureFlags'`,
+      output: `import {DefaultFeatureFlags} from '@primer/react/experimental'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/FeatureFlags/DefaultFeatureFlags',
+          },
         },
       ],
     },

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -229,7 +229,7 @@ module.exports = {
             message: `Wildcard imports from ${node.source.value} are not allowed. Import from an entrypoint instead`,
             *fix(fixer) {
               for (const [entrypoint, importSpecifiers] of changes) {
-                const allTypeImports = importSpecifiers.every(([_, __, type]) => type === 'type')
+                const allTypeImports = importSpecifiers.every(([, , type]) => type === 'type')
                 const importStatement = allTypeImports ? 'import type' : 'import'
                 const specifiers = importSpecifiers
                   .map(([imported, local, type]) => {

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -3,67 +3,37 @@
 const url = require('../url')
 
 const wildcardImports = new Map([
+  // Components
   [
-    '@primer/react/lib-esm/sx',
+    '@primer/react/lib-esm/Button/ButtonBase',
     [
       {
         type: 'type',
-        name: 'BetterSystemStyleObject',
+        name: 'ButtonBaseProps',
         from: '@primer/react',
       },
       {
-        type: 'type',
-        name: 'SxProp',
-        from: '@primer/react',
-      },
-      {
-        type: 'type',
-        name: 'BetterCssProperties',
+        name: 'ButtonBase',
         from: '@primer/react',
       },
     ],
   ],
   [
-    '@primer/react/lib-esm/useIsomorphicLayoutEffect',
-    [
-      {
-        name: 'default',
-        from: '@primer/react',
-        as: 'useIsomorphicLayoutEffect',
-      },
-    ],
-  ],
-  [
-    '@primer/react/lib-esm/Token/IssueLabelToken',
+    '@primer/react/lib-esm/Button/types',
     [
       {
         type: 'type',
-        name: 'IssueLabelTokenProps',
+        name: 'ButtonBaseProps',
         from: '@primer/react',
       },
     ],
   ],
   [
-    '@primer/react/lib-esm/deprecated/ActionList',
+    '@primer/react/lib-esm/Dialog/Dialog',
     [
       {
-        type: 'type',
-        name: 'ItemProps',
-        from: '@primer/react/deprecated',
-      },
-    ],
-  ],
-  [
-    '@primer/react/lib-esm/deprecated/ActionList/List',
-    [
-      {
-        type: 'type',
-        name: 'GroupedListProps',
-        from: '@primer/react/deprecated',
-      },
-      {
-        name: 'ItemInput',
-        from: '@primer/react/deprecated',
+        name: 'Dialog',
+        from: '@primer/react/experimental',
       },
     ],
   ],
@@ -82,12 +52,92 @@ const wildcardImports = new Map([
     ],
   ],
   [
+    '@primer/react/lib-esm/Label/Label',
+    [
+      {
+        type: 'type',
+        name: 'LabelColorOptions',
+        from: '@primer/react',
+      },
+    ],
+  ],
+  [
     '@primer/react/lib-esm/_VisuallyHidden',
     [
       {
         name: 'default',
         from: '@primer/react',
         as: 'VisuallyHidden',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/Token/IssueLabelToken',
+    [
+      {
+        type: 'type',
+        name: 'IssueLabelTokenProps',
+        from: '@primer/react',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/Token/TokenBase',
+    [
+      {
+        type: 'type',
+        name: 'TokenSizeKeys',
+        from: '@primer/react',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/deprecated/ActionList',
+    [
+      {
+        type: 'type',
+        name: 'ItemProps',
+        from: '@primer/react/deprecated',
+        as: 'ActionListItemProps',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/deprecated/ActionList/List',
+    [
+      {
+        type: 'type',
+        name: 'GroupedListProps',
+        from: '@primer/react/deprecated',
+        as: 'ActionListGroupedListProps',
+      },
+      {
+        name: 'ItemInput',
+        from: '@primer/react/deprecated',
+        as: 'ActionListItemInput',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/deprecated/ActionList/Item',
+    [
+      {
+        type: 'type',
+        name: 'ItemProps',
+        from: '@primer/react/deprecated',
+        as: 'ActionListItemProps',
+      },
+    ],
+  ],
+
+  // Hooks
+  [
+    '@primer/react/lib-esm/useIsomorphicLayoutEffect',
+    [
+      {
+        name: 'default',
+        from: '@primer/react',
+        as: 'useIsomorphicLayoutEffect',
       },
     ],
   ],
@@ -112,46 +162,53 @@ const wildcardImports = new Map([
     ],
   ],
   [
-    '@primer/react/lib-esm/Button/types',
-    [
-      {
-        type: 'type',
-        name: 'ButtonBaseProps',
-        from: '@primer/react',
-      },
-      {
-        name: 'ButtonBase',
-        from: '@primer/react',
-      },
-    ],
-  ],
-  [
-    '@primer/react/lib-esm/utils/polymorphic',
-    [
-      {
-        type: 'type',
-        name: 'ForwardRefComponent',
-        from: '@primer/react',
-      },
-    ],
-  ],
-  [
     '@primer/react/lib-esm/hooks/useResponsiveValue',
     [
       {
-        type: 'type',
-        name: 'useResponsiveValue',
+        name: 'default',
         from: '@primer/react',
         as: 'useResponsiveValue',
       },
     ],
   ],
+
+  // Utilities
   [
-    '@primer/react/lib-esm/Dialog/Dialog',
+    '@primer/react/lib-esm/sx',
     [
       {
-        name: 'Dialog',
+        type: 'type',
+        name: 'BetterSystemStyleObject',
+        from: '@primer/react',
+      },
+      {
+        type: 'type',
+        name: 'SxProp',
+        from: '@primer/react',
+      },
+      {
+        type: 'type',
+        name: 'BetterCssProperties',
+        from: '@primer/react',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/FeatureFlags/DefaultFeatureFlags',
+    [
+      {
+        name: 'DefaultFeatureFlags',
         from: '@primer/react/experimental',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/theme',
+    [
+      {
+        name: 'default',
+        from: '@primer/react',
+        as: 'theme',
       },
     ],
   ],
@@ -170,81 +227,144 @@ module.exports = {
     },
     fixable: true,
     schema: [],
+    messages: {
+      unknownWildcardImport:
+        'Wildcard imports from @primer/react are not allowed. Import from @primer/react, @primer/react/experimental, or @primer/react/deprecated instead',
+      knownWildcardImport:
+        'Wildcard import {{ specifier }} from {{ wildcardEntrypoint }} are not allowed. Import from @primer/react, @primer/react/experimental, or @primer/react/deprecated instead',
+      wildcardMigration:
+        'Wildcard imports from {{ wildcardEntrypoint }} are not allowed. Import from @primer/react, @primer/react/experimental, or @primer/react/deprecated instead',
+    },
   },
   create(context) {
     return {
       ImportDeclaration(node) {
-        if (!node.source.value.startsWith('@primer/react/lib-esm')) {
-          return
-        }
+        try {
+          if (!node.source.value.startsWith('@primer/react/lib-esm')) {
+            return
+          }
 
-        const wildcardImportMigrations = wildcardImports.get(node.source.value)
-        if (!wildcardImportMigrations) {
-          context.report({
-            node,
-            message: 'Wildcard imports from @primer/react are not allowed. Import from an entrypoint instead',
-          })
-          return
-        }
-
-        /**
-         * Maps entrypoint to array of changes. This tuple contains the new
-         * imported name from the entrypoint along with the existing local name
-         * @type {Map<string, Array<[string, string]>>}
-         */
-        const changes = new Map()
-
-        for (const specifier of node.specifiers) {
-          const migration = wildcardImportMigrations.find(migration => {
-            if (specifier.type === 'ImportDefaultSpecifier') {
-              return migration.name === 'default'
-            }
-            return specifier.imported.name === migration.name
-          })
-
-          // If we do not have a migration, we should report an error even if we
-          // cannot autofix it
-          if (!migration) {
+          const wildcardImportMigrations = wildcardImports.get(node.source.value)
+          if (!wildcardImportMigrations) {
             context.report({
               node,
-              message: `Wildcard import ${specifier.imported.name} from ${node.source.value} is not allowed. Import from an entrypoint instead`,
+              messageId: 'unknownWildcardImport',
             })
-            break
+            return
           }
 
-          if (!changes.has(migration.from)) {
-            changes.set(migration.from, [])
+          /**
+           * Maps entrypoint to array of changes. This tuple contains the new
+           * imported name from the entrypoint along with the existing local name
+           * @type {Map<string, Array<[string, string]>>}
+           */
+          const changes = new Map()
+
+          for (const specifier of node.specifiers) {
+            const migration = wildcardImportMigrations.find(migration => {
+              if (specifier.type === 'ImportDefaultSpecifier') {
+                return migration.name === 'default'
+              }
+              return specifier.imported.name === migration.name
+            })
+
+            // If we do not have a migration, we should report an error even if we
+            // cannot autofix it
+            if (!migration) {
+              context.report({
+                node,
+                messageId: 'unknownWildcardImport',
+              })
+              return
+            }
+
+            if (!changes.has(migration.from)) {
+              changes.set(migration.from, [])
+            }
+
+            if (migration.as) {
+              changes.get(migration.from).push([migration.as, migration.as, migration.type])
+            } else {
+              changes.get(migration.from).push([migration.name, specifier.local.name, migration.type])
+            }
           }
 
-          if (migration.as) {
-            changes.get(migration.from).push([migration.as, migration.as, migration.type])
-          } else {
-            changes.get(migration.from).push([migration.name, specifier.local.name, migration.type])
+          if (changes.length === 0) {
+            return
           }
-        }
 
-        if (changes.length !== 0) {
           context.report({
             node,
-            message: `Wildcard imports from ${node.source.value} are not allowed. Import from an entrypoint instead`,
+            messageId: 'wildcardMigration',
+            data: {
+              wildcardEntrypoint: node.source.value,
+            },
             *fix(fixer) {
               for (const [entrypoint, importSpecifiers] of changes) {
-                const allTypeImports = importSpecifiers.every(([, , type]) => type === 'type')
-                const importStatement = allTypeImports ? 'import type' : 'import'
-                const specifiers = importSpecifiers
-                  .map(([imported, local, type]) => {
-                    const prefix = allTypeImports ? '' : type === 'type' ? 'type ' : ''
-                    if (imported === local) {
-                      return `${prefix}${imported}`
-                    }
+                const typeSpecifiers = importSpecifiers.filter(([, , type]) => {
+                  return type === 'type'
+                })
 
-                    return `${prefix}${imported} as ${local}`
+                // If all imports are type imports, emit emit as `import type {specifier} from '...'`
+                if (typeSpecifiers.length === importSpecifiers.length) {
+                  const namedSpecifiers = typeSpecifiers.filter(([imported]) => {
+                    return imported !== 'default'
                   })
-                  .join(', ')
-                yield fixer.replaceText(node, `${importStatement} {${specifiers}} from '${entrypoint}'`)
+                  const defaultSpecifier = typeSpecifiers.find(([imported]) => {
+                    return imported === 'default'
+                  })
+
+                  if (namedSpecifiers.length > 0 && !defaultSpecifier) {
+                    const specifiers = namedSpecifiers.map(([imported, local]) => {
+                      if (imported !== local) {
+                        return `${imported} as ${local}`
+                      }
+                      return imported
+                    })
+                    yield fixer.replaceText(node, `import type {${specifiers.join(', ')}} from '${entrypoint}'`)
+                  } else if (namedSpecifiers.length > 0 && defaultSpecifier) {
+                    yield fixer.replaceText(
+                      node,
+                      `import type ${defaultSpecifier[1]}, ${specifiers.join(', ')} from '${entrypoint}'`,
+                    )
+                  } else if (defaultSpecifier && namedSpecifiers.length === 0) {
+                    yield fixer.replaceText(node, `import type ${defaultSpecifier[1]} from '${entrypoint}'`)
+                  }
+
+                  return
+                }
+
+                // Otherwise, we have a mix of type and value imports to emit
+                const valueSpecifiers = importSpecifiers.filter(([, , type]) => {
+                  return type !== 'type'
+                })
+
+                if (valueSpecifiers.length === 0) {
+                  return
+                }
+
+                const specifiers = valueSpecifiers.map(([imported, local]) => {
+                  if (imported !== local) {
+                    return `${imported} as ${local}`
+                  }
+                  return imported
+                })
+                yield fixer.replaceText(node, `import {${specifiers.join(', ')}} from '${entrypoint}'`)
+
+                if (typeSpecifiers.length > 0) {
+                  const specifiers = valueSpecifiers.map(([imported, local]) => {
+                    if (imported !== local) {
+                      return `${imported} as ${local}`
+                    }
+                    return imported
+                  })
+                  yield fixer.insertTextAfter(node, `import type {${specifiers.join(', ')}} from '${entrypoint}'`)
+                }
               }
             },
           })
+        } catch (error) {
+          console.log(error)
         }
       },
     }

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -1,0 +1,252 @@
+'use strict'
+
+const url = require('../url')
+
+const wildcardImports = new Map([
+  [
+    '@primer/react/lib-esm/sx',
+    [
+      {
+        type: 'type',
+        name: 'BetterSystemStyleObject',
+        from: '@primer/react',
+      },
+      {
+        type: 'type',
+        name: 'SxProp',
+        from: '@primer/react',
+      },
+      {
+        type: 'type',
+        name: 'BetterCssProperties',
+        from: '@primer/react',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/useIsomorphicLayoutEffect',
+    [
+      {
+        name: 'default',
+        from: '@primer/react',
+        as: 'useIsomorphicLayoutEffect',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/Token/IssueLabelToken',
+    [
+      {
+        type: 'type',
+        name: 'IssueLabelTokenProps',
+        from: '@primer/react',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/deprecated/ActionList',
+    [
+      {
+        type: 'type',
+        name: 'ItemProps',
+        from: '@primer/react/deprecated',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/deprecated/ActionList/List',
+    [
+      {
+        type: 'type',
+        name: 'GroupedListProps',
+        from: '@primer/react/deprecated',
+      },
+      {
+        name: 'ItemInput',
+        from: '@primer/react/deprecated',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/SelectPanel/SelectPanel',
+    [
+      {
+        name: 'SelectPanel',
+        from: '@primer/react/experimental',
+      },
+      {
+        type: 'type',
+        name: 'SelectPanelProps',
+        from: '@primer/react/experimental',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/_VisuallyHidden',
+    [
+      {
+        name: 'default',
+        from: '@primer/react',
+        as: 'VisuallyHidden',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/hooks/useResizeObserver',
+    [
+      {
+        name: 'default',
+        from: '@primer/react',
+        as: 'useResizeObserver',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/hooks/useProvidedRefOrCreate',
+    [
+      {
+        name: 'default',
+        from: '@primer/react',
+        as: 'useProvidedRefOrCreate',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/Button/types',
+    [
+      {
+        type: 'type',
+        name: 'ButtonBaseProps',
+        from: '@primer/react',
+      },
+      {
+        name: 'ButtonBase',
+        from: '@primer/react',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/utils/polymorphic',
+    [
+      {
+        type: 'type',
+        name: 'ForwardRefComponent',
+        from: '@primer/react',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/hooks/useResponsiveValue',
+    [
+      {
+        type: 'type',
+        name: 'useResponsiveValue',
+        from: '@primer/react',
+        as: 'useResponsiveValue',
+      },
+    ],
+  ],
+  [
+    '@primer/react/lib-esm/Dialog/Dialog',
+    [
+      {
+        name: 'Dialog',
+        from: '@primer/react/experimental',
+      },
+    ],
+  ],
+])
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Wildcard imports are discouraged. Import from a main entrypoint instead',
+      recommended: true,
+      url: url(module),
+    },
+    fixable: true,
+    schema: [],
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (!node.source.value.startsWith('@primer/react/lib-esm')) {
+          return
+        }
+
+        const wildcardImportMigrations = wildcardImports.get(node.source.value)
+        if (!wildcardImportMigrations) {
+          context.report({
+            node,
+            message: 'Wildcard imports from @primer/react are not allowed. Import from an entrypoint instead',
+          })
+          return
+        }
+
+        /**
+         * Maps entrypoint to array of changes. This tuple contains the new
+         * imported name from the entrypoint along with the existing local name
+         * @type {Map<string, Array<[string, string]>>}
+         */
+        const changes = new Map()
+
+        for (const specifier of node.specifiers) {
+          const migration = wildcardImportMigrations.find(migration => {
+            if (specifier.type === 'ImportDefaultSpecifier') {
+              return migration.name === 'default'
+            }
+            return specifier.imported.name === migration.name
+          })
+
+          // If we do not have a migration, we should report an error even if we
+          // cannot autofix it
+          if (!migration) {
+            context.report({
+              node,
+              message: `Wildcard import ${specifier.imported.name} from ${node.source.value} is not allowed. Import from an entrypoint instead`,
+            })
+            break
+          }
+
+          if (!changes.has(migration.from)) {
+            changes.set(migration.from, [])
+          }
+
+          if (migration.as) {
+            changes.get(migration.from).push([migration.as, migration.as, migration.type])
+          } else {
+            changes.get(migration.from).push([migration.name, specifier.local.name, migration.type])
+          }
+        }
+
+        if (changes.length !== 0) {
+          context.report({
+            node,
+            message: `Wildcard imports from ${node.source.value} are not allowed. Import from an entrypoint instead`,
+            *fix(fixer) {
+              for (const [entrypoint, importSpecifiers] of changes) {
+                const allTypeImports = importSpecifiers.every(([_, __, type]) => type === 'type')
+                const importStatement = allTypeImports ? 'import type' : 'import'
+                const specifiers = importSpecifiers
+                  .map(([imported, local, type]) => {
+                    const prefix = allTypeImports ? '' : type === 'type' ? 'type ' : ''
+                    if (imported === local) {
+                      return `${prefix}${imported}`
+                    }
+
+                    return `${prefix}${imported} as ${local}`
+                  })
+                  .join(', ')
+                yield fixer.replaceText(node, `${importStatement} {${specifiers}} from '${entrypoint}'`)
+              }
+            },
+          })
+        }
+      },
+    }
+  },
+}


### PR DESCRIPTION
Add support for the No Wildcard Imports rule. This rule will warn against imports from `@primer/react/lib-esm` and will attempt to autofix them if the path is known 👀 

Note: this is not added to the recommended set of rules and instead will be enabled manually on target repos.