### PR TITLE
fix(no-wildcard-imports): use local name when changing imports

### DIFF
--- a/.changeset/shy-news-care.md
+++ b/.changeset/shy-news-care.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-primer-react': patch
+---
+
+Update no-wildcard-imports rule to use local name for updated imports

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-primer-react",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-primer-react",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "dependencies": {
         "@styled-system/props": "^5.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-primer-react",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-primer-react",
-      "version": "6.0.2",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "@styled-system/props": "^5.1.5",

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -71,13 +71,13 @@ ruleTester.run('no-wildcard-imports', rule, {
 
     // Test default import
     {
-      code: `import useIsomorphicLayoutEffect from '@primer/react/lib-esm/useIsomorphicLayoutEffect'`,
+      code: `import useIsomorphicLayoutEffect from '@primer/react/lib-esm/utils/useIsomorphicLayoutEffect'`,
       output: `import {useIsomorphicLayoutEffect} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
           data: {
-            wildcardEntrypoint: '@primer/react/lib-esm/useIsomorphicLayoutEffect',
+            wildcardEntrypoint: '@primer/react/lib-esm/utils/useIsomorphicLayoutEffect',
           },
         },
       ],
@@ -85,8 +85,8 @@ ruleTester.run('no-wildcard-imports', rule, {
 
     // Test multiple wildcard imports into single entrypoint
     {
-      code: `import useResizeObserver from '@primer/react/lib-esm/hooks/useResizeObserver'
-    import useIsomorphicLayoutEffect from '@primer/react/lib-esm/useIsomorphicLayoutEffect'`,
+      code: `import {useResizeObserver} from '@primer/react/lib-esm/hooks/useResizeObserver'
+    import useIsomorphicLayoutEffect from '@primer/react/lib-esm/utils/useIsomorphicLayoutEffect'`,
       output: `import {useResizeObserver} from '@primer/react'
     import {useIsomorphicLayoutEffect} from '@primer/react'`,
       errors: [
@@ -99,7 +99,7 @@ ruleTester.run('no-wildcard-imports', rule, {
         {
           messageId: 'wildcardMigration',
           data: {
-            wildcardEntrypoint: '@primer/react/lib-esm/useIsomorphicLayoutEffect',
+            wildcardEntrypoint: '@primer/react/lib-esm/utils/useIsomorphicLayoutEffect',
           },
         },
       ],
@@ -291,13 +291,13 @@ import type {ButtonBaseProps} from '@primer/react'`,
 
     // @primer/react/lib-esm/useIsomorphicLayoutEffect
     {
-      code: `import useIsomorphicLayoutEffect from '@primer/react/lib-esm/useIsomorphicLayoutEffect'`,
+      code: `import useIsomorphicLayoutEffect from '@primer/react/lib-esm/utils/useIsomorphicLayoutEffect'`,
       output: `import {useIsomorphicLayoutEffect} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
           data: {
-            wildcardEntrypoint: '@primer/react/lib-esm/useIsomorphicLayoutEffect',
+            wildcardEntrypoint: '@primer/react/lib-esm/utils/useIsomorphicLayoutEffect',
           },
         },
       ],
@@ -305,7 +305,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
 
     // @primer/react/lib-esm/hooks/useResizeObserver
     {
-      code: `import useResizeObserver from '@primer/react/lib-esm/hooks/useResizeObserver'`,
+      code: `import {useResizeObserver} from '@primer/react/lib-esm/hooks/useResizeObserver'`,
       output: `import {useResizeObserver} from '@primer/react'`,
       errors: [
         {
@@ -319,7 +319,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
 
     // @primer/react/lib-esm/hooks/useProvidedRefOrCreate
     {
-      code: `import useProvidedRefOrCreate from '@primer/react/lib-esm/hooks/useProvidedRefOrCreate'`,
+      code: `import {useProvidedRefOrCreate} from '@primer/react/lib-esm/hooks/useProvidedRefOrCreate'`,
       output: `import {useProvidedRefOrCreate} from '@primer/react'`,
       errors: [
         {
@@ -333,7 +333,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
 
     // @primer/react/lib-esm/hooks/useResponsiveValue
     {
-      code: `import useResponsiveValue from '@primer/react/lib-esm/hooks/useResponsiveValue'`,
+      code: `import {useResponsiveValue} from '@primer/react/lib-esm/hooks/useResponsiveValue'`,
       output: `import {useResponsiveValue} from '@primer/react'`,
       errors: [
         {

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -168,7 +168,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import {SelectPanel} from '@primer/react/lib-esm/SelectPanel/SelectPanel'`,
-      output: `import {SelectPanel} from '@primer/react`,
+      output: `import {SelectPanel} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -168,7 +168,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import {SelectPanel} from '@primer/react/lib-esm/SelectPanel/SelectPanel'`,
-      output: `import {SelectPanel} from '@primer/react/experimental'`,
+      output: `import {SelectPanel} from '@primer/react/deprecated'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -180,7 +180,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {SelectPanelProps} from '@primer/react/lib-esm/SelectPanel/SelectPanel'`,
-      output: `import type {SelectPanelProps} from '@primer/react/experimental'`,
+      output: `import type {SelectPanelProps} from '@primer/react/deprecated'`,
       errors: [
         {
           messageId: 'wildcardMigration',

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -105,6 +105,20 @@ ruleTester.run('no-wildcard-imports', rule, {
       ],
     },
 
+    // Test renamed wildcard imports
+    {
+      code: `import type {ItemProps} from '@primer/react/lib-esm/deprecated/ActionList/Item'`,
+      output: `import type {ActionListItemProps as ItemProps} from '@primer/react/deprecated'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/deprecated/ActionList/Item',
+          },
+        },
+      ],
+    },
+
     // Test migrations
 
     // Components --------------------------------------------------------------
@@ -226,7 +240,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {ItemProps} from '@primer/react/lib-esm/deprecated/ActionList'`,
-      output: `import type {ActionListItemProps} from '@primer/react/deprecated'`,
+      output: `import type {ActionListItemProps as ItemProps} from '@primer/react/deprecated'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -238,7 +252,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {GroupedListProps} from '@primer/react/lib-esm/deprecated/ActionList/List'`,
-      output: `import type {ActionListGroupedListProps} from '@primer/react/deprecated'`,
+      output: `import type {ActionListGroupedListProps as GroupedListProps} from '@primer/react/deprecated'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -250,7 +264,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import {ItemInput} from '@primer/react/lib-esm/deprecated/ActionList/List'`,
-      output: `import {ActionListItemInput} from '@primer/react/deprecated'`,
+      output: `import {ActionListItemInput as ItemInput} from '@primer/react/deprecated'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -262,7 +276,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {ItemProps} from '@primer/react/lib-esm/deprecated/ActionList/Item'`,
-      output: `import type {ActionListItemProps} from '@primer/react/deprecated'`,
+      output: `import type {ActionListItemProps as ItemProps} from '@primer/react/deprecated'`,
       errors: [
         {
           messageId: 'wildcardMigration',

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -168,7 +168,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import {SelectPanel} from '@primer/react/lib-esm/SelectPanel/SelectPanel'`,
-      output: `import {SelectPanel} from '@primer/react/deprecated'`,
+      output: `import {SelectPanel} from '@primer/react`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -180,7 +180,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {SelectPanelProps} from '@primer/react/lib-esm/SelectPanel/SelectPanel'`,
-      output: `import type {SelectPanelProps} from '@primer/react/deprecated'`,
+      output: `import type {SelectPanelProps} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -47,12 +47,12 @@ const wildcardImports = new Map([
     [
       {
         name: 'SelectPanel',
-        from: '@primer/react/experimental',
+        from: '@primer/react/deprecated',
       },
       {
         type: 'type',
         name: 'SelectPanelProps',
-        from: '@primer/react/experimental',
+        from: '@primer/react/deprecated',
       },
     ],
   ],

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -132,7 +132,7 @@ const wildcardImports = new Map([
 
   // Hooks
   [
-    '@primer/react/lib-esm/useIsomorphicLayoutEffect',
+    '@primer/react/lib-esm/utils/useIsomorphicLayoutEffect',
     [
       {
         name: 'default',
@@ -145,9 +145,8 @@ const wildcardImports = new Map([
     '@primer/react/lib-esm/hooks/useResizeObserver',
     [
       {
-        name: 'default',
+        name: 'useResizeObserver',
         from: '@primer/react',
-        as: 'useResizeObserver',
       },
     ],
   ],
@@ -155,9 +154,8 @@ const wildcardImports = new Map([
     '@primer/react/lib-esm/hooks/useProvidedRefOrCreate',
     [
       {
-        name: 'default',
+        name: 'useProvidedRefOrCreate',
         from: '@primer/react',
-        as: 'useProvidedRefOrCreate',
       },
     ],
   ],
@@ -165,9 +163,8 @@ const wildcardImports = new Map([
     '@primer/react/lib-esm/hooks/useResponsiveValue',
     [
       {
-        name: 'default',
+        name: 'useResponsiveValue',
         from: '@primer/react',
-        as: 'useResponsiveValue',
       },
     ],
   ],

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -47,12 +47,12 @@ const wildcardImports = new Map([
     [
       {
         name: 'SelectPanel',
-        from: '@primer/react/deprecated',
+        from: '@primer/react',
       },
       {
         type: 'type',
         name: 'SelectPanelProps',
-        from: '@primer/react/deprecated',
+        from: '@primer/react',
       },
     ],
   ],

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -35,6 +35,11 @@ const wildcardImports = new Map([
         name: 'Dialog',
         from: '@primer/react/experimental',
       },
+      {
+        name: 'DialogHeaderProps',
+        from: '@primer/react/experimental',
+        type: 'type',
+      },
     ],
   ],
   [
@@ -354,7 +359,7 @@ module.exports = {
                   }
                   return imported
                 })
-                yield fixer.insertTextAfter(node, `import type {${specifiers.join(', ')}} from '${entrypoint}'`)
+                yield fixer.insertTextAfter(node, `\nimport type {${specifiers.join(', ')}} from '${entrypoint}'`)
               }
             }
           },

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -237,6 +237,7 @@ module.exports = {
     },
   },
   create(context) {
+    const sourceCode = context.sourceCode
     return {
       ImportDeclaration(node) {
         if (!node.source.value.startsWith('@primer/react/lib-esm')) {
@@ -282,7 +283,7 @@ module.exports = {
           }
 
           if (migration.as) {
-            changes.get(migration.from).push([migration.as, migration.as, migration.type])
+            changes.get(migration.from).push([migration.as, specifier.local.name, migration.type])
           } else {
             changes.get(migration.from).push([migration.name, specifier.local.name, migration.type])
           }

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -237,7 +237,6 @@ module.exports = {
     },
   },
   create(context) {
-    const sourceCode = context.sourceCode
     return {
       ImportDeclaration(node) {
         if (!node.source.value.startsWith('@primer/react/lib-esm')) {


### PR DESCRIPTION
Small update to our wildcard import rules so that imports that are renamed keep the same local name in the file. This makes it easier for us to codemod 😅 

```diff
-import {ItemProps} from '@primer/react/lib-esm/deprecated/ActionList';
+import {ActionListItemProps as ItemProps} from '@primer/react/deprecated';
```

_Edit: this also updates some of the imports to hooks that I had incorrectly implemented_