### PR TITLE
fix(no-wildcard-imports): support test-helpers, mix-and-match imports

### DIFF
--- a/.changeset/pink-feet-provide.md
+++ b/.changeset/pink-feet-provide.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-primer-react': patch
+---
+
+Update no-wildcard-imports rule to work for imports that specify value and type imports

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -373,6 +373,18 @@ import type {ButtonBaseProps} from '@primer/react'`,
         },
       ],
     },
+    {
+      code: `import type {ResponsiveValue} from '@primer/react/lib-esm/hooks/useResponsiveValue'`,
+      output: `import type {ResponsiveValue} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/hooks/useResponsiveValue',
+          },
+        },
+      ],
+    },
 
     // Utilities ---------------------------------------------------------------
 

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -119,7 +119,36 @@ ruleTester.run('no-wildcard-imports', rule, {
       ],
     },
 
+    // Test mixed imports
+    {
+      code: `import {Dialog, type DialogProps} from '@primer/react/lib-esm/Dialog/Dialog'`,
+      output: `import {Dialog} from '@primer/react/experimental'
+import type {DialogProps} from '@primer/react/experimental'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/Dialog/Dialog',
+          },
+        },
+      ],
+    },
+
     // Test migrations
+
+    // Test helpers ------------------------------------------------------------
+    {
+      code: `import '@primer/react/lib-esm/utils/test-helpers'`,
+      output: `import '@primer/react/test-helpers'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/utils/test-helpers',
+          },
+        },
+      ],
+    },
 
     // Components --------------------------------------------------------------
     {

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -220,6 +220,15 @@ const wildcardImports = new Map([
     ],
   ],
   [
+    '@primer/react/lib-esm/FeatureFlags/useFeatureFlag',
+    [
+      {
+        name: 'useFeatureFlag',
+        from: '@primer/react/experimental',
+      },
+    ],
+  ],
+  [
     '@primer/react/lib-esm/theme',
     [
       {

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -29,20 +29,6 @@ const wildcardImports = new Map([
     ],
   ],
   [
-    '@primer/react/lib-esm/Dialog',
-    [
-      {
-        name: 'Dialog',
-        from: '@primer/react/experimental',
-      },
-      {
-        name: 'DialogHeaderProps',
-        from: '@primer/react/experimental',
-        type: 'type',
-      },
-    ],
-  ],
-  [
     '@primer/react/lib-esm/Dialog/Dialog',
     [
       {
@@ -193,6 +179,11 @@ const wildcardImports = new Map([
     [
       {
         name: 'useResponsiveValue',
+        from: '@primer/react',
+      },
+      {
+        type: 'type',
+        name: 'ResponsiveValue',
         from: '@primer/react',
       },
     ],

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -29,6 +29,20 @@ const wildcardImports = new Map([
     ],
   ],
   [
+    '@primer/react/lib-esm/Dialog',
+    [
+      {
+        name: 'Dialog',
+        from: '@primer/react/experimental',
+      },
+      {
+        name: 'DialogHeaderProps',
+        from: '@primer/react/experimental',
+        type: 'type',
+      },
+    ],
+  ],
+  [
     '@primer/react/lib-esm/Dialog/Dialog',
     [
       {
@@ -37,6 +51,16 @@ const wildcardImports = new Map([
       },
       {
         name: 'DialogHeaderProps',
+        from: '@primer/react/experimental',
+        type: 'type',
+      },
+      {
+        name: 'DialogProps',
+        from: '@primer/react/experimental',
+        type: 'type',
+      },
+      {
+        name: 'DialogButtonProps',
         from: '@primer/react/experimental',
         type: 'type',
       },
@@ -245,6 +269,20 @@ module.exports = {
           return
         }
 
+        if (node.source.value === '@primer/react/lib-esm/utils/test-helpers') {
+          context.report({
+            node,
+            messageId: 'wildcardMigration',
+            data: {
+              wildcardEntrypoint: node.source.value,
+            },
+            fix(fixer) {
+              return fixer.replaceText(node.source, `'@primer/react/test-helpers'`)
+            },
+          })
+          return
+        }
+
         const wildcardImportMigrations = wildcardImports.get(node.source.value)
         if (!wildcardImportMigrations) {
           context.report({
@@ -353,7 +391,7 @@ module.exports = {
               yield fixer.replaceText(node, `import {${specifiers.join(', ')}} from '${entrypoint}'`)
 
               if (typeSpecifiers.length > 0) {
-                const specifiers = valueSpecifiers.map(([imported, local]) => {
+                const specifiers = typeSpecifiers.map(([imported, local]) => {
                   if (imported !== local) {
                     return `${imported} as ${local}`
                   }


### PR DESCRIPTION
Update our `no-wildcard-import` rule to work in the following scenarios:

- When someone imports from `@primer/react/lib-esm/utils/test-helpers`
- When someone uses both type and value imports in a single import statement