### PR TITLE
fix(no-wildcard-imports): mix-and-match import types

### DIFF
--- a/.changeset/grumpy-masks-lie.md
+++ b/.changeset/grumpy-masks-lie.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-primer-react': patch
+---
+
+Update no-wildcard-imports rule to not create separate imports for type only imports. This prevents an issue downstream with autofixers

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -122,13 +122,27 @@ ruleTester.run('no-wildcard-imports', rule, {
     // Test mixed imports
     {
       code: `import {Dialog, type DialogProps} from '@primer/react/lib-esm/Dialog/Dialog'`,
-      output: `import {Dialog} from '@primer/react/experimental'
-import type {DialogProps} from '@primer/react/experimental'`,
+      output: `import {Dialog, type DialogProps} from '@primer/react/experimental'`,
       errors: [
         {
           messageId: 'wildcardMigration',
           data: {
             wildcardEntrypoint: '@primer/react/lib-esm/Dialog/Dialog',
+          },
+        },
+      ],
+    },
+
+    // Use existing imports
+    {
+      code: `import {Box, type BoxProps} from '@primer/react'
+import type {BetterSystemStyleObject} from '@primer/react/lib-esm/sx'`,
+      output: `import {Box, type BoxProps, type BetterSystemStyleObject} from '@primer/react'`,
+      errors: [
+        {
+          messageId: 'wildcardMigration',
+          data: {
+            wildcardEntrypoint: '@primer/react/lib-esm/sx',
           },
         },
       ],
@@ -414,5 +428,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
         },
       ],
     },
-  ],
+  ].filter((item, index) => {
+    return index === 7
+  }),
 })

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -30,7 +30,7 @@ ruleTester.run('no-wildcard-imports', rule, {
     // Test type import
     {
       code: `import type {SxProp} from '@primer/react/lib-esm/sx'`,
-      output: `import type {SxProp} from '@primer/react'`,
+      output: `import {type SxProp} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -44,7 +44,7 @@ ruleTester.run('no-wildcard-imports', rule, {
     // Test multiple type imports
     {
       code: `import type {BetterSystemStyleObject, SxProp, BetterCssProperties} from '@primer/react/lib-esm/sx'`,
-      output: `import type {BetterSystemStyleObject, SxProp, BetterCssProperties} from '@primer/react'`,
+      output: `import {type BetterSystemStyleObject, type SxProp, type BetterCssProperties} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -58,7 +58,7 @@ ruleTester.run('no-wildcard-imports', rule, {
     // Test import alias
     {
       code: `import type {SxProp as RenamedSxProp} from '@primer/react/lib-esm/sx'`,
-      output: `import type {SxProp as RenamedSxProp} from '@primer/react'`,
+      output: `import {type SxProp as RenamedSxProp} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -108,7 +108,7 @@ ruleTester.run('no-wildcard-imports', rule, {
     // Test renamed wildcard imports
     {
       code: `import type {ItemProps} from '@primer/react/lib-esm/deprecated/ActionList/Item'`,
-      output: `import type {ActionListItemProps as ItemProps} from '@primer/react/deprecated'`,
+      output: `import {type ActionListItemProps as ItemProps} from '@primer/react/deprecated'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -137,7 +137,8 @@ ruleTester.run('no-wildcard-imports', rule, {
     {
       code: `import {Box, type BoxProps} from '@primer/react'
 import type {BetterSystemStyleObject} from '@primer/react/lib-esm/sx'`,
-      output: `import {Box, type BoxProps, type BetterSystemStyleObject} from '@primer/react'`,
+      output: `import {Box, type BoxProps, type BetterSystemStyleObject} from '@primer/react'
+`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -169,7 +170,7 @@ import type {BetterSystemStyleObject} from '@primer/react/lib-esm/sx'`,
       code: `import {ButtonBase} from '@primer/react/lib-esm/Button/ButtonBase';
 import type {ButtonBaseProps} from '@primer/react/lib-esm/Button/ButtonBase'`,
       output: `import {ButtonBase} from '@primer/react'
-import type {ButtonBaseProps} from '@primer/react'`,
+import {type ButtonBaseProps} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -187,7 +188,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {ButtonBaseProps} from '@primer/react/lib-esm/Button/types'`,
-      output: `import type {ButtonBaseProps} from '@primer/react'`,
+      output: `import {type ButtonBaseProps} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -223,7 +224,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {SelectPanelProps} from '@primer/react/lib-esm/SelectPanel/SelectPanel'`,
-      output: `import type {SelectPanelProps} from '@primer/react'`,
+      output: `import {type SelectPanelProps} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -235,7 +236,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {LabelColorOptions} from '@primer/react/lib-esm/Label/Label'`,
-      output: `import type {LabelColorOptions} from '@primer/react'`,
+      output: `import {type LabelColorOptions} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -259,7 +260,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {IssueLabelTokenProps} from '@primer/react/lib-esm/Token/IssueLabelToken'`,
-      output: `import type {IssueLabelTokenProps} from '@primer/react'`,
+      output: `import {type IssueLabelTokenProps} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -271,7 +272,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {TokenSizeKeys} from '@primer/react/lib-esm/Token/TokenBase'`,
-      output: `import type {TokenSizeKeys} from '@primer/react'`,
+      output: `import {type TokenSizeKeys} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -283,7 +284,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {ItemProps} from '@primer/react/lib-esm/deprecated/ActionList'`,
-      output: `import type {ActionListItemProps as ItemProps} from '@primer/react/deprecated'`,
+      output: `import {type ActionListItemProps as ItemProps} from '@primer/react/deprecated'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -295,7 +296,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {GroupedListProps} from '@primer/react/lib-esm/deprecated/ActionList/List'`,
-      output: `import type {ActionListGroupedListProps as GroupedListProps} from '@primer/react/deprecated'`,
+      output: `import {type ActionListGroupedListProps as GroupedListProps} from '@primer/react/deprecated'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -319,7 +320,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {ItemProps} from '@primer/react/lib-esm/deprecated/ActionList/Item'`,
-      output: `import type {ActionListItemProps as ItemProps} from '@primer/react/deprecated'`,
+      output: `import {type ActionListItemProps as ItemProps} from '@primer/react/deprecated'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -389,7 +390,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     },
     {
       code: `import type {ResponsiveValue} from '@primer/react/lib-esm/hooks/useResponsiveValue'`,
-      output: `import type {ResponsiveValue} from '@primer/react'`,
+      output: `import {type ResponsiveValue} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -405,7 +406,7 @@ import type {ButtonBaseProps} from '@primer/react'`,
     // @primer/react/lib-esm/sx
     {
       code: `import type {BetterSystemStyleObject, SxProp, BetterCssProperties} from '@primer/react/lib-esm/sx'`,
-      output: `import type {BetterSystemStyleObject, SxProp, BetterCssProperties} from '@primer/react'`,
+      output: `import {type BetterSystemStyleObject, type SxProp, type BetterCssProperties} from '@primer/react'`,
       errors: [
         {
           messageId: 'wildcardMigration',
@@ -428,7 +429,5 @@ import type {ButtonBaseProps} from '@primer/react'`,
         },
       ],
     },
-  ].filter((item, index) => {
-    return index === 7
-  }),
+  ],
 })

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -406,7 +406,7 @@ module.exports = {
               // Reuse a type import if it exists
               if (typeImportDeclaration) {
                 const firstSpecifier = typeImportDeclaration.specifiers[0]
-                const lastSpecifier = typeImportDeclaration.specifiers[importDeclaration.specifiers.length - 1]
+                const lastSpecifier = typeImportDeclaration.specifiers[typeImportDeclaration.specifiers.length - 1]
 
                 if (defaultTypeSpecifier) {
                   const postfix =

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -386,10 +386,11 @@ module.exports = {
                   throw new Error('Import Declaration has no specifiers')
                 }
 
-                let lastSpecifier = importDeclaration.specifiers[importDeclaration.specifiers.length - 1]
+                const firstSpecifier = importDeclaration.specifiers[0]
+                const lastSpecifier = importDeclaration.specifiers[importDeclaration.specifiers.length - 1]
 
                 if (hasDefaultSpecifier) {
-                  console.log('wat')
+                  yield fixer.insertTextBefore(firstSpecifier, `${defaultSpecifier}, `)
                 }
 
                 if (hasNamedSpecifiers) {

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -365,7 +365,7 @@ module.exports = {
                 )
               })
               const namedSpecifiers = importSpecifiers
-                .filter(([imported, _local, type]) => {
+                .filter(([imported, , type]) => {
                   return imported !== 'default' && type !== 'type'
                 })
                 .map(([imported, local, type]) => {
@@ -376,7 +376,7 @@ module.exports = {
                   return `${prefix}${imported}`
                 })
               const namedTypeSpecifiers = importSpecifiers
-                .filter(([imported, _local, type]) => {
+                .filter(([imported, , type]) => {
                   return imported !== 'default' && type === 'type'
                 })
                 .map(([imported, local, type]) => {
@@ -386,13 +386,13 @@ module.exports = {
                   }
                   return `${prefix}${imported}`
                 })
-              let defaultSpecifier = importSpecifiers.find(([imported, _local, type]) => {
+              let defaultSpecifier = importSpecifiers.find(([imported, , type]) => {
                 return imported === 'default' && type !== 'type'
               })
               if (defaultSpecifier) {
                 defaultSpecifier = defaultSpecifier[1]
               }
-              let defaultTypeSpecifier = importSpecifiers.find(([imported, _local, type]) => {
+              let defaultTypeSpecifier = importSpecifiers.find(([imported, , type]) => {
                 return imported === 'default' && type === 'type'
               })
               if (defaultTypeSpecifier) {
@@ -411,7 +411,7 @@ module.exports = {
                 if (defaultTypeSpecifier) {
                   const postfix =
                     namedTypeSpecifiers.length > 0 || typeImportDeclaration.specifiers.length > 0 ? ', ' : ' '
-                  yield fix.insertTextBeforeRange(
+                  yield fixer.insertTextBeforeRange(
                     [firstSpecifier.range[0] - 1, firstSpecifier.range[1]],
                     `${defaultTypeSpecifier}${postfix}`,
                   )
@@ -429,7 +429,7 @@ module.exports = {
 
                 if (defaultSpecifier) {
                   const postfix = namedSpecifiers.length > 0 || importDeclaration.specifiers.length > 0 ? ', ' : ' '
-                  yield fix.insertTextBeforeRange(
+                  yield fixer.insertTextBeforeRange(
                     [firstSpecifier.range[0] - 1, firstSpecifier.range[1]],
                     `${defaultSpecifier}${postfix}`,
                   )


### PR DESCRIPTION
Update our logic for this rule to reuse existing imports as best we can to avoid autofix errors downstream 😓 