### PR TITLE
fix(no-wildcard-imports): remove migration for TokenSizeKeys

### DIFF
--- a/.changeset/short-garlics-kiss.md
+++ b/.changeset/short-garlics-kiss.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-primer-react': patch
+---
+
+Update no-wildcard-imports rule to no longer migrate the TokenSizeKeys import

--- a/src/rules/__tests__/no-wildcard-imports.test.js
+++ b/src/rules/__tests__/no-wildcard-imports.test.js
@@ -271,18 +271,6 @@ import {type ButtonBaseProps} from '@primer/react/experimental'`,
       ],
     },
     {
-      code: `import type {TokenSizeKeys} from '@primer/react/lib-esm/Token/TokenBase'`,
-      output: `import {type TokenSizeKeys} from '@primer/react'`,
-      errors: [
-        {
-          messageId: 'wildcardMigration',
-          data: {
-            wildcardEntrypoint: '@primer/react/lib-esm/Token/TokenBase',
-          },
-        },
-      ],
-    },
-    {
       code: `import type {ItemProps} from '@primer/react/lib-esm/deprecated/ActionList'`,
       output: `import {type ActionListItemProps as ItemProps} from '@primer/react/deprecated'`,
       errors: [

--- a/src/rules/no-wildcard-imports.js
+++ b/src/rules/no-wildcard-imports.js
@@ -97,16 +97,6 @@ const wildcardImports = new Map([
     ],
   ],
   [
-    '@primer/react/lib-esm/Token/TokenBase',
-    [
-      {
-        type: 'type',
-        name: 'TokenSizeKeys',
-        from: '@primer/react',
-      },
-    ],
-  ],
-  [
     '@primer/react/lib-esm/deprecated/ActionList',
     [
       {


### PR DESCRIPTION
Update this rule since we found a way to migrate this upstream to just read from the prop value instead.