### PR TITLE
extend enforce-css-module-identifier-casing to support destructured imports

### DIFF
--- a/src/rules/__tests__/enforce-css-module-identifier-casing.test.js
+++ b/src/rules/__tests__/enforce-css-module-identifier-casing.test.js
@@ -19,10 +19,20 @@ ruleTester.run('enforce-css-module-identifier-casing', rule, {
     'import classes from "a.module.css"; function Foo() { return <Box className={`${classes.Foo}`}/> }',
     'import classes from "a.module.css"; function Foo() { return <Box className={`${classes["Foo"]}`}/> }',
     'import classes from "a.module.css"; let x = "Foo"; function Foo() { return <Box className={`${classes[x]}`}/> }',
+    'import {Foo} from "a.module.css"; function Bar() { return <Box className={Foo}/> }',
   ],
   invalid: [
     {
       code: 'import classes from "a.module.css"; function Foo() { return <Box className={classes.foo}/> }',
+      errors: [
+        {
+          messageId: 'pascal',
+          data: {name: 'foo'},
+        },
+      ],
+    },
+    {
+      code: 'import {foo} from "a.module.css"; function Bar() { return <Box className={foo}/> }',
       errors: [
         {
           messageId: 'pascal',

--- a/src/utils/css-modules.js
+++ b/src/utils/css-modules.js
@@ -4,8 +4,8 @@ function importBindingIsFromCSSModuleImport(node) {
 
 function identifierIsCSSModuleBinding(node, context) {
   if (node.type !== 'Identifier') return false
-  const ref = context.getScope().references.find(reference => reference.identifier.name === node.name)
-  if (ref.resolved?.defs?.some(importBindingIsFromCSSModuleImport)) {
+  const ref = context.sourceCode.getScope(node).references.find(reference => reference.identifier.name === node.name)
+  if (ref && ref.resolved?.defs?.some(importBindingIsFromCSSModuleImport)) {
     return true
   }
   return false


### PR DESCRIPTION
Refs https://github.com/github/primer/issues/4248

This rule didn't properly support raw identifiers (in the case of destructured imports)