### PR TITLE
Add new rule `a11y-no-title-usage`

### DIFF
--- a/.changeset/nine-mirrors-float.md
+++ b/.changeset/nine-mirrors-float.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-primer-react': major
+---
+
+Add `a11y-no-title-usage` that warns against using `title` in some components

--- a/docs/rules/a11y-no-title-usage.md
+++ b/docs/rules/a11y-no-title-usage.md
@@ -18,7 +18,7 @@ import {RelativeTime} from '@primer/react'
 const App = () => <RelativeTime date={new Date('2020-01-01T00:00:00Z')} />
 ```
 
-The `noTitle` attribute can be omitted because its default value is `true` internally.
+The noTitle attribute is true by default, so it can be omitted.
 
 ## With alternative tooltip
 

--- a/docs/rules/a11y-no-title-usage.md
+++ b/docs/rules/a11y-no-title-usage.md
@@ -7,7 +7,7 @@ This rule aims to prevent the use of the `title` attribute with some components 
 ```jsx
 import {RelativeTime} from '@primer/react'
 
-<RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle={false} />
+const App = () => <RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle={false} />
 ```
 
 👍 Examples of **correct** code for this rule:
@@ -15,7 +15,7 @@ import {RelativeTime} from '@primer/react'
 ```jsx
 import {RelativeTime} from '@primer/react'
 
-<RelativeTime date={new Date('2020-01-01T00:00:00Z')} />
+const App = () => <RelativeTime date={new Date('2020-01-01T00:00:00Z')} />
 ```
 
 The `noTitle` attribute can be omitted because its default value is `true` internally.

--- a/docs/rules/a11y-no-title-usage.md
+++ b/docs/rules/a11y-no-title-usage.md
@@ -1,0 +1,21 @@
+## Rule Details
+
+This rule aims to prevent the use of the `title` attribute with some components from `@primer/react`. The `title` attribute is not keyboard accessible, which results in accessibility issues. Instead, we should utilize alternatives that are accessible.
+
+👎 Examples of **incorrect** code for this rule
+
+```jsx
+import {RelativeTime} from '@primer/react'
+
+<RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle={false} />
+```
+
+👍 Examples of **correct** code for this rule:
+
+```jsx
+import {RelativeTime} from '@primer/react'
+
+<RelativeTime date={new Date('2020-01-01T00:00:00Z')} />
+```
+
+The `noTitle` attribute can be omitted because its default value is `true` internally.

--- a/docs/rules/a11y-no-title-usage.md
+++ b/docs/rules/a11y-no-title-usage.md
@@ -19,3 +19,22 @@ const App = () => <RelativeTime date={new Date('2020-01-01T00:00:00Z')} />
 ```
 
 The `noTitle` attribute can be omitted because its default value is `true` internally.
+
+## With alternative tooltip
+
+If you want to still utilize a tooltip in a similar way to how the `title` attribute works, you can use the [Primer `Tooltip`](https://primer.style/components/tooltip/react/beta). If you use the `Tooltip` component, you must use it with an interactive element, such as with a button or a link.
+
+```jsx
+import {RelativeTime, Tooltip} from '@primer/react'
+
+const App = () => {
+  const date = new Date('2020-01-01T00:00:00Z')
+  return (
+    <Tooltip text={date.toString()}>
+      <Link href="#">
+        <RelativeTime date={date} noTitle={true} />
+      </Link>
+    </Tooltip>
+  )
+}
+```

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -15,6 +15,7 @@ module.exports = {
     'primer-react/a11y-tooltip-interactive-trigger': 'error',
     'primer-react/new-color-css-vars': 'error',
     'primer-react/a11y-explicit-heading': 'error',
+    'primer-react/a11y-no-title-usage': 'error',
     'primer-react/no-deprecated-props': 'warn',
     'primer-react/a11y-remove-disable-tooltip': 'error',
     'primer-react/a11y-use-accessible-tooltip': 'error',

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ module.exports = {
     'a11y-link-in-text-block': require('./rules/a11y-link-in-text-block'),
     'a11y-remove-disable-tooltip': require('./rules/a11y-remove-disable-tooltip'),
     'a11y-use-accessible-tooltip': require('./rules/a11y-use-accessible-tooltip'),
+    'a11y-no-title-usage': require('./rules/a11y-no-title-usage'),
     'use-deprecated-from-deprecated': require('./rules/use-deprecated-from-deprecated'),
     'no-wildcard-imports': require('./rules/no-wildcard-imports'),
     'no-unnecessary-components': require('./rules/no-unnecessary-components'),

--- a/src/rules/__tests__/a11y-no-title-usage.test.js
+++ b/src/rules/__tests__/a11y-no-title-usage.test.js
@@ -1,0 +1,32 @@
+const rule = require('../a11y-no-title-usage')
+const {RuleTester} = require('eslint')
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+ruleTester.run('a11y-no-title-usage', rule, {
+  valid: [
+    `import {RelativeTime} from '@primer/react';
+  <RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle={true} />`,
+    `import {RelativeTime} from '@primer/react';
+  <RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle />`,
+    `import {RelativeTime} from '@primer/react';
+  <RelativeTime date={new Date('2020-01-01T00:00:00Z')} />`,
+  ],
+  invalid: [
+    {
+      code: `import {RelativeTime} from '@primer/react'; <RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle={false} />`,
+      output: `import {RelativeTime} from '@primer/react'; <RelativeTime date={new Date('2020-01-01T00:00:00Z')} />`,
+      errors: [{messageId: 'noTitleOnRelativeTime'}],
+    },
+  ],
+})

--- a/src/rules/__tests__/a11y-no-title-usage.test.js
+++ b/src/rules/__tests__/a11y-no-title-usage.test.js
@@ -13,17 +13,14 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('a11y-no-title-usage', rule, {
   valid: [
-    `import {RelativeTime} from '@primer/react';
-  <RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle={true} />`,
-    `import {RelativeTime} from '@primer/react';
-  <RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle />`,
-    `import {RelativeTime} from '@primer/react';
-  <RelativeTime date={new Date('2020-01-01T00:00:00Z')} />`,
+    `<RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle={true} />`,
+    `<RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle />`,
+    `<RelativeTime date={new Date('2020-01-01T00:00:00Z')} />`,
   ],
   invalid: [
     {
-      code: `import {RelativeTime} from '@primer/react'; <RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle={false} />`,
-      output: `import {RelativeTime} from '@primer/react'; <RelativeTime date={new Date('2020-01-01T00:00:00Z')} />`,
+      code: `<RelativeTime date={new Date('2020-01-01T00:00:00Z')} noTitle={false} />`,
+      output: `<RelativeTime date={new Date('2020-01-01T00:00:00Z')} />`,
       errors: [{messageId: 'noTitleOnRelativeTime'}],
     },
   ],

--- a/src/rules/__tests__/a11y-no-title-usage.test.js
+++ b/src/rules/__tests__/a11y-no-title-usage.test.js
@@ -2,13 +2,11 @@ const rule = require('../a11y-no-title-usage')
 const {RuleTester} = require('eslint')
 
 const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
-      ecmaFeatures: {
-        jsx: true,
-      },
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
     },
   },
 })

--- a/src/rules/a11y-no-title-usage.js
+++ b/src/rules/a11y-no-title-usage.js
@@ -1,0 +1,37 @@
+const {getJSXOpeningElementAttribute} = require('../utils/get-jsx-opening-element-attribute')
+
+module.exports = {
+  meta: {
+    type: 'error', // TODO: Confirm the type
+    docs: {
+      description: 'Disallow usage of title attribute on some components',
+      recommended: true,
+      url: null, // TODO: Add URL
+    },
+    messages: {
+      noTitleOnRelativeTime: 'Avoid using the title attribute on RelativeTime.',
+    },
+    fixable: 'code',
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      JSXOpeningElement(jsxNode) {
+        const title = getJSXOpeningElementAttribute(jsxNode, 'noTitle')
+
+        if (title && title.value && title.value.expression && title.value.expression.value !== true) {
+          context.report({
+            node: title,
+            messageId: 'noTitleOnRelativeTime',
+            fix(fixer) {
+              const start = title.range[0] - 1 // Accounts for whitespace
+              const end = title.range[1]
+              return fixer.removeRange([start, end])
+            },
+          })
+        }
+      },
+    }
+  },
+}

--- a/src/rules/a11y-no-title-usage.js
+++ b/src/rules/a11y-no-title-usage.js
@@ -1,18 +1,18 @@
+const url = require('../url')
 const {getJSXOpeningElementAttribute} = require('../utils/get-jsx-opening-element-attribute')
 
 module.exports = {
   meta: {
-    type: 'error', // TODO: Confirm the type
+    type: 'error',
     docs: {
       description: 'Disallow usage of title attribute on some components',
       recommended: true,
-      url: null, // TODO: Add URL
+      url: url(module),
     },
     messages: {
       noTitleOnRelativeTime: 'Avoid using the title attribute on RelativeTime.',
     },
     fixable: 'code',
-    schema: [],
   },
 
   create(context) {
@@ -25,7 +25,7 @@ module.exports = {
             node: title,
             messageId: 'noTitleOnRelativeTime',
             fix(fixer) {
-              const start = title.range[0] - 1 // Accounts for whitespace
+              const start = title.range[0] - 1
               const end = title.range[1]
               return fixer.removeRange([start, end])
             },


### PR DESCRIPTION
Adds new rule `a11y-no-title-usage`. 

This rule recommends that consumers do not utilize the title attribute with the RelativeTime component. This attribute is inherent to the component, so adding the prop noTitle is currently necessary.

**The suggested paths for remediating violations found through this rule are:** 

* Utilize the [Primer `Tooltip`](https://primer.style/components/tooltip/react/beta) in with an interactive element
* Place the `title` date adjacent or near the `RelativeTime` component
* Remove `title` if it isn't needed

**Questions for reviewers:** 

* This rule is mainly for `relative-time-element`, so should the name reference `relative-time-element`?
* The goal is that this rule will eventually no longer be needed and we can deprecate it. `noTitle` will also be deprecated
* Is there anything else we should look out for?

Context: https://github.com/github/primer/issues/4769