### PR TITLE
Update recommended.js

### DIFF
--- a/.changeset/eighty-tips-deliver.md
+++ b/.changeset/eighty-tips-deliver.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+Update message for no-deprecated-experimental-components rule

--- a/.changeset/honest-adults-add.md
+++ b/.changeset/honest-adults-add.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+Removes primer-react/enforce-css-module-identifier-casing, primer-react/enforce-css-module-default-import from recommended set of rules.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-primer-react",
-  "version": "6.1.6",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-primer-react",
-      "version": "6.1.6",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "@styled-system/props": "^5.1.5",

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -22,8 +22,6 @@ module.exports = {
     'primer-react/a11y-use-accessible-tooltip': 'error',
     'primer-react/no-unnecessary-components': 'error',
     'primer-react/prefer-action-list-item-onselect': 'error',
-    'primer-react/enforce-css-module-identifier-casing': 'error',
-    'primer-react/enforce-css-module-default-import': ['error', {enforceName: '(^classes$|Classes$)'}],
   },
   settings: {
     github: {

--- a/src/rules/__tests__/no-deprecated-experimental-components.test.js
+++ b/src/rules/__tests__/no-deprecated-experimental-components.test.js
@@ -30,14 +30,14 @@ ruleTester.run('no-deprecated-experimental-components', rule, {
     {
       code: `import {SelectPanel} from '@primer/react/experimental'`,
       errors: [
-        'SelectPanel is deprecated. Please import from the stable entrypoint (@primer/react) if available, or check https://primer.style/product/components/ for alternative components.',
+        'The experimental SelectPanel is deprecated. Please import from the stable entrypoint (@primer/react) if available, or check https://primer.style/product/components/ for alternative components.',
       ],
     },
     // Multiple experimental import
     {
       code: `import {SelectPanel, DataTable, ActionBar} from '@primer/react/experimental'`,
       errors: [
-        'SelectPanel is deprecated. Please import from the stable entrypoint (@primer/react) if available, or check https://primer.style/product/components/ for alternative components.',
+        'The experimental SelectPanel is deprecated. Please import from the stable entrypoint (@primer/react) if available, or check https://primer.style/product/components/ for alternative components.',
       ],
     },
   ],

--- a/src/rules/no-deprecated-experimental-components.js
+++ b/src/rules/no-deprecated-experimental-components.js
@@ -52,7 +52,7 @@ module.exports = {
         }
 
         if (experimental.length > 0) {
-          const message = `${components.join(', ')} ${
+          const message = `The experimental ${components.join(', ')} ${
             components.length > 1 ? 'are' : 'is'
           } deprecated. Please import from the stable entrypoint (@primer/react) if available, or check https://primer.style/product/components/ for alternative components.`
 

--- a/src/rules/no-deprecated-experimental-components.js
+++ b/src/rules/no-deprecated-experimental-components.js
@@ -52,6 +52,7 @@ module.exports = {
         }
 
         if (experimental.length > 0) {
+          // eslint-disable-next-line i18n-text/no-en
           const message = `The experimental ${components.join(', ')} ${
             components.length > 1 ? 'are' : 'is'
           } deprecated. Please import from the stable entrypoint (@primer/react) if available, or check https://primer.style/product/components/ for alternative components.`


### PR DESCRIPTION
- Removes primer-react/enforce-css-module-identifier-casing, primer-react/enforce-css-module-default-import from recommended set of rules.
- Updates message for no-deprecated-experimental-components rule
