### PR TITLE
Add optional chain to return

### DIFF
--- a/.changeset/proud-terms-fetch.md
+++ b/.changeset/proud-terms-fetch.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-primer-react': patch
+---
+
+Fixes error when `imported` does not exist in specifier object

--- a/src/rules/__tests__/no-deprecated-experimental-components.test.js
+++ b/src/rules/__tests__/no-deprecated-experimental-components.test.js
@@ -24,6 +24,9 @@ ruleTester.run('no-deprecated-experimental-components', rule, {
     {
       code: `import {DataTable, ActionBar} from '@primer/react/experimental'`,
     },
+    {
+      code: `import * as RandomComponent from '@primer/react/experimental'`,
+    },
   ],
   invalid: [
     // Single experimental import

--- a/src/rules/no-deprecated-experimental-components.js
+++ b/src/rules/no-deprecated-experimental-components.js
@@ -42,7 +42,7 @@ module.exports = {
         const entrypoint = entrypoints.get(node.source.value)
 
         const experimental = node.specifiers.filter(specifier => {
-          return entrypoint.has(specifier.imported.name)
+          return entrypoint.has(specifier.imported?.name)
         })
 
         const components = experimental.map(specifier => specifier.imported.name)

--- a/src/rules/no-deprecated-experimental-components.js
+++ b/src/rules/no-deprecated-experimental-components.js
@@ -45,7 +45,7 @@ module.exports = {
           return entrypoint.has(specifier.imported?.name)
         })
 
-        const components = experimental.map(specifier => specifier.imported.name)
+        const components = experimental.map(specifier => specifier.imported?.name)
 
         if (experimental.length === 0) {
           return


### PR DESCRIPTION
Fixes an error when `imported` does not exist in the specifier object. Adds an optional chain to return for cases where `imported` isn't present.