### PR TITLE
Add more components to `use-styled-react-import` rule

### DIFF
--- a/src/rules/use-styled-react-import.js
+++ b/src/rules/use-styled-react-import.js
@@ -32,7 +32,7 @@ const defaultStyledComponents = [
   'Truncate',
   'Octicon',
   'Dialog',
-  'UnderlineNav'
+  'UnderlineNav',
 ]
 
 // Default types that should be imported from @primer/styled-react


### PR DESCRIPTION
Adds missing components to the `use-styled-react-import` ESLint rule that are imported from `@primer/react` but used with `sx` props.

This change is based on [Datadog analytics](https://app.datadoghq.com/notebook/12999641/primer-react-v38-stats-cloned?cell_id=jewmhkxl&tpl_var_component%5B0%5D=%2A&tpl_var_repo%5B0%5D=%2A)

<img width="1050" height="570" alt="Screenshot 2025-09-12 at 2 53 47 PM" src="https://github.com/user-attachments/assets/c88a907f-6367-4ead-a524-be86e509eafa" />
