### PR TITLE
Add Sidebar to SplitPageLayout props set

### DIFF
--- a/.changeset/short-teeth-cheat.md
+++ b/.changeset/short-teeth-cheat.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-primer-react": patch
+---
+
+Add SplitPageLayout.Sidebar to no-system-props exclusions for padding, position, and width.

--- a/src/rules/no-system-props.js
+++ b/src/rules/no-system-props.js
@@ -34,6 +34,7 @@ const excludedComponentProps = new Map([
   ['SplitPageLayout.Footer', new Set(['padding'])],
   ['SplitPageLayout.Pane', new Set(['padding', 'position', 'width'])],
   ['SplitPageLayout.Content', new Set(['padding', 'width'])],
+  ['SplitPageLayout.Sidebar', new Set(['padding', 'position', 'width'])],
   ['StyledOcticon', new Set(['size'])],
   ['Octicon', new Set(['size', 'color'])],
   ['PointerBox', new Set(['bg'])],


### PR DESCRIPTION
This pull request makes a small update to the `excludedComponentProps` map in `src/rules/no-system-props.js` to ensure consistent property exclusions for the `SplitPageLayout.Sidebar` component.

* Added `SplitPageLayout.Sidebar` to the `excludedComponentProps` map with the excluded props `padding`, `position`, and `width`.