### PR TITLE
Adding eslint 10 support

### DIFF
--- a/.changeset/clear-keys-design.md
+++ b/.changeset/clear-keys-design.md
@@ -1,0 +1,7 @@
+---
+'eslint-plugin-primer-react': minor
+---
+
+Remove plugin:github/react from src/configs/recommended.js to avoid silently depending on GitHub’s React config behavior.
+Expand this package’s eslint peer dependency range to include ESLint ^10.0.0.
+Update the lockfile to reflect the peer dependency change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "eslint": "^9.0.0"
+        "eslint": "^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/primer/eslint-plugin-primer-react#readme",
   "peerDependencies": {
-    "eslint": "^9.0.0"
+    "eslint": "^9.0.0 || ^10.0.0"
   },
   "dependencies": {
     "@typescript-eslint/utils": "^8.50.0",

--- a/src/configs/recommended.js
+++ b/src/configs/recommended.js
@@ -8,7 +8,6 @@ module.exports = {
     },
   },
   plugins: ['primer-react', 'github'],
-  extends: ['plugin:github/react'],
   rules: {
     'primer-react/direct-slot-children': 'error',
 


### PR DESCRIPTION
This is an initial attempt to remove blocking dependencies for ESlint 10 migration as part of: https://github.com/github/web-systems/issues/5207#issuecomment-4895176908

## Why This Was Changed

1. Removes hidden coupling between plugins  
   `primer-react` no longer silently depends on `github/react` behavior.

2. Avoids duplicate rule application  
   If github-ui repo config already applies GitHub React rules, this prevents applying them twice.

## How It Relates to the Migration

1. This is a support change for migration stability, not the core migration itself.
2. It fits the cleanup and decoupling phase (dedupe and dependency hygiene).
3. The core migration still happens in your shared/base ESLint config architecture (flat config consolidation), while this change reduces risk and surprises during that process.

Other repos (if any outside of github-ui) where the package is used may need to be validated with this changes, otherwise this could only be used to create an `eslint-lint-10-valid-temp-version` and later reverted to unblock `github-ui` migration.